### PR TITLE
Handle TF drift more gracefully for `ti_resource_group` and `ti_resource_group_assignment`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/petoju/terraform-provider-mysql/v3
+module github.com/zph/terraform-provider-mysql/v3
 
 require (
 	cloud.google.com/go/cloudsqlconn v1.11.0

--- a/main.go
+++ b/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/plugin"
-	"github.com/petoju/terraform-provider-mysql/v3/mysql"
+	"github.com/zph/terraform-provider-mysql/v3/mysql"
 )
 
 func main() {

--- a/mysql/resource_ti_resource_group.go
+++ b/mysql/resource_ti_resource_group.go
@@ -180,7 +180,7 @@ func ReadResourceGroup(ctx context.Context, d *schema.ResourceData, meta interfa
 		return nil
 	}
 
-	setResourceGroupOnResourceData(rg, d)
+	setResourceGroupOnResourceData(*rg, d)
 	return nil
 }
 

--- a/mysql/resource_ti_resource_group_user_assignment.go
+++ b/mysql/resource_ti_resource_group_user_assignment.go
@@ -48,7 +48,7 @@ func CreateOrUpdateResourceGroupUser(ctx context.Context, d *schema.ResourceData
 	var warnLevel, warnMessage string
 	var warnCode int = 0
 
-	currentUser, _, err = readUserFromDB(db, user)
+	currentUser, _, err := readUserFromDB(db, user)
 	if err != nil {
 		d.SetId("")
 		return diag.Errorf(`error during get user (%s): %s`, user, err)

--- a/mysql/resource_ti_resource_group_user_assignment.go
+++ b/mysql/resource_ti_resource_group_user_assignment.go
@@ -48,10 +48,15 @@ func CreateOrUpdateResourceGroupUser(ctx context.Context, d *schema.ResourceData
 	var warnLevel, warnMessage string
 	var warnCode int = 0
 
-	_, _, err = readUserFromDB(db, user)
+	currentUser, _, err = readUserFromDB(db, user)
 	if err != nil {
 		d.SetId("")
-		return diag.Errorf(`must create user first before assigning to resource group | getting user %s | error %s`, user, err)
+		return diag.Errorf(`error during get user (%s): %s`, user, err)
+	}
+
+	if currentUser == "" {
+		d.SetId("")
+		return diag.Errorf(`must create user first before assigning to resource group | getting user %s | error %s`, currentUser, err)
 	}
 
 	sql := fmt.Sprintf("ALTER USER `%s` RESOURCE GROUP `%s`", user, resourceGroup)
@@ -88,8 +93,15 @@ func ReadResourceGroupUser(ctx context.Context, d *schema.ResourceData, meta int
 		return diag.Errorf(`error getting user %s`, err)
 	}
 
+	// If the user doesn't exist, instead of erroring, recognize that there's
+	// terraform drift and attempt to create the assignment again.
+	if user == "" {
+		d.SetId("")
+		return nil
+	}
+
 	d.Set("user", user)
-	d.Set("resourceGroup", resourceGroup)
+	d.Set("resource_group", resourceGroup)
 
 	return nil
 }
@@ -102,6 +114,7 @@ func DeleteResourceGroupUser(ctx context.Context, d *schema.ResourceData, meta i
 	if err != nil {
 		return diag.FromErr(err)
 	}
+
 	deleteQuery := fmt.Sprintf("ALTER USER `%s` RESOURCE GROUP `default`", user)
 	_, err = db.Exec(deleteQuery)
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
@@ -120,7 +133,8 @@ func readUserFromDB(db *sql.DB, name string) (string, string, error) {
 
 	err := row.Scan(&user, &resourceGroup)
 	if errors.Is(err, sql.ErrNoRows) {
-		return "", "", sql.ErrNoRows
+		log.Printf("[DEBUG] resource group doesn't exist (%s): %s", name, err)
+		return "", "", nil
 	} else if err != nil {
 		return "", "", fmt.Errorf(`error fetching user %e`, err)
 	}


### PR DESCRIPTION
[This article](https://www.hashicorp.com/blog/writing-custom-terraform-providers) provides a good initial explanation of the expected behaviors of the different CRUD methods for a resource.

In it, it mentions that the `Read` method should be able to gracefully handle when the resource no longer exists (probably due to manual deletion). 

I also fixed a bug where `resourceGroup` was supposed to be `resource_group` and also modified `petoju` --> `zph` in certain places. This makes error logs a bit more clear.