### PR TITLE
Fixes TF drift for resource group name and query_limit

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,7 +5,7 @@ on:
     branches: ["master"]
     tags: ["*"]
   pull_request:
-    branches: [ "master" ]
+    branches: [ "*" ]
 jobs:
   lint:
     runs-on: ubuntu-22.04

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,8 +38,7 @@ jobs:
         # Track https://github.com/pingcap/tidb/tags
         - testtidb6.1.0
         - testtidb6.5.3
-        # Fails because not yet available? 20240705
-        # - testtidb6.5.10
+        - testtidb6.5.10
         - testtidb7.1.5
         - testtidb7.5.2
         - testtidb8.1.0

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,7 +38,7 @@ jobs:
         # Track https://github.com/pingcap/tidb/tags
         - testtidb6.1.0
         - testtidb6.5.3
-        - testtidb6.5.10
+        # - testtidb6.5.10
         - testtidb7.1.5
         - testtidb7.5.2
         - testtidb8.1.0

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -43,7 +43,11 @@ bin/terraform:
 	(cd $(CURDIR)/bin/ ; unzip terraform.zip)
 
 testacc: fmtcheck bin/terraform
-	PATH="$(CURDIR)/bin:${PATH}" TF_ACC=1 go test $(TEST) -v $(TESTARGS) -timeout=90s
+	TF_ACC=1 go test $(TEST) -v $(TESTARGS) -timeout=90s
+	# Commenting out the below because it tries to use an amd64 version of terraform that is incompatible with M1 Macs. Instead,
+	# simply rely on the version of terraform that's already on your path. If you don't have terraform installed, follow instructions
+	# here to install https://developer.hashicorp.com/terraform/tutorials/aws-get-started/install-cli
+	# PATH="$(CURDIR)/bin:${PATH}" TF_ACC=1 go test $(TEST) -v $(TESTARGS) -run "TestTIDBResourceGroup_basic" -timeout=90s
 
 acceptance: testversion5.6 testversion5.7 testversion8.0 testpercona5.7 testpercona8.0 testmariadb10.3 testmariadb10.8 testmariadb10.10 testtidb6.1.0 testtidb7.5.2
 

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -11,18 +11,20 @@ DATESTAMP=$(shell date "+%Y%m%d")
 SHA_SHORT=$(shell git describe --match=FORCE_NEVER_MATCH --always --abbrev=40 --dirty --abbrev)
 MOST_RECENT_UPSTREAM_TAG=$(shell git for-each-ref refs/tags --sort=-taggerdate --format="%(refname)" | head -1 | grep -E -o "v\d+\.\d+\.\d+")
 
-OS_ARCH=linux_amd64
-
 # Set correct OS_ARCH on Mac
 UNAME := $(shell uname -s)
 HW := $(shell uname -m)
+ifeq ($(HW),arm64)
+	ARCH=$(HW)
+else
+	ARCH=amd64
+endif
+
 ifeq ($(UNAME),Darwin)
-	ifeq ($(HW),arm64)
-		ARCH=$(HW)
-	else
-		ARCH=amd64
-	endif
 	OS_ARCH=darwin_$(ARCH)
+else
+	ARCH=amd64
+	OS_ARCH=linux_$(ARCH)
 endif
 
 HOSTNAME=registry.terraform.io

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -12,10 +12,11 @@ SHA_SHORT=$(shell git describe --match=FORCE_NEVER_MATCH --always --abbrev=40 --
 MOST_RECENT_UPSTREAM_TAG=$(shell git for-each-ref refs/tags --sort=-taggerdate --format="%(refname)" | head -1 | grep -E -o "v\d+\.\d+\.\d+")
 
 OS_ARCH=linux_amd64
+
 # Set correct OS_ARCH on Mac
 UNAME := $(shell uname -s)
+HW := $(shell uname -m)
 ifeq ($(UNAME),Darwin)
-	HW := $(shell uname -m)
 	ifeq ($(HW),arm64)
 		ARCH=$(HW)
 	else

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -44,10 +44,11 @@ bin/terraform:
 
 testacc: fmtcheck bin/terraform
 	TF_ACC=1 go test $(TEST) -v $(TESTARGS) -timeout=90s
-	# Commenting out the below because it tries to use an amd64 version of terraform that is incompatible with M1 Macs. Instead,
-	# simply rely on the version of terraform that's already on your path. If you don't have terraform installed, follow instructions
-	# here to install https://developer.hashicorp.com/terraform/tutorials/aws-get-started/install-cli
-	# PATH="$(CURDIR)/bin:${PATH}" TF_ACC=1 go test $(TEST) -v $(TESTARGS) -run "TestTIDBResourceGroup_basic" -timeout=90s
+
+# Commenting out the below because it tries to use an amd64 version of terraform that is incompatible with M1 Macs. Instead,
+# simply rely on the version of terraform that's already on your path. If you don't have terraform installed, follow instructions
+# here to install https://developer.hashicorp.com/terraform/tutorials/aws-get-started/install-cli
+# PATH="$(CURDIR)/bin:${PATH}" TF_ACC=1 go test $(TEST) -v $(TESTARGS) -run "TestTIDBResourceGroup_basic" -timeout=90s
 
 acceptance: testversion5.6 testversion5.7 testversion8.0 testpercona5.7 testpercona8.0 testmariadb10.3 testmariadb10.8 testmariadb10.10 testtidb6.1.0 testtidb7.5.2
 

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -46,11 +46,6 @@ bin/terraform:
 testacc: fmtcheck bin/terraform
 	PATH="$(CURDIR)/bin:${PATH}" TF_ACC=1 go test $(TEST) -v $(TESTARGS) -timeout=90s
 
-# Commenting out the below because it tries to use an amd64 version of terraform that is incompatible with M1 Macs. Instead,
-# simply rely on the version of terraform that's already on your path. If you don't have terraform installed, follow instructions
-# here to install https://developer.hashicorp.com/terraform/tutorials/aws-get-started/install-cli
-# PATH="$(CURDIR)/bin:${PATH}" TF_ACC=1 go test $(TEST) -v $(TESTARGS) -run "TestTIDBResourceGroup_basic" -timeout=90s
-
 acceptance: testversion5.6 testversion5.7 testversion8.0 testpercona5.7 testpercona8.0 testmariadb10.3 testmariadb10.8 testmariadb10.10 testtidb6.1.0 testtidb7.5.2
 
 testversion%:

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -2,7 +2,8 @@ TEST?=$$(go list ./... |grep -v 'vendor')
 GOFMT_FILES?=$$(find . -name '*.go' |grep -v vendor)
 WEBSITE_REPO=github.com/hashicorp/terraform-website
 PKG_NAME=mysql
-TERRAFORM_VERSION=0.14.7
+# Last version before hashicorp relicensing to BSL
+TERRAFORM_VERSION=1.5.6
 TERRAFORM_OS=$(shell uname -s | tr A-Z a-z)
 TEST_USER=root
 TEST_PASSWORD=my-secret-pw
@@ -39,11 +40,11 @@ test: acceptance
 
 bin/terraform:
 	mkdir -p "$(CURDIR)/bin"
-	curl -sfL https://releases.hashicorp.com/terraform/$(TERRAFORM_VERSION)/terraform_$(TERRAFORM_VERSION)_$(TERRAFORM_OS)_amd64.zip > $(CURDIR)/bin/terraform.zip
+	curl -sfL https://releases.hashicorp.com/terraform/$(TERRAFORM_VERSION)/terraform_$(TERRAFORM_VERSION)_$(TERRAFORM_OS)_$(ARCH).zip > $(CURDIR)/bin/terraform.zip
 	(cd $(CURDIR)/bin/ ; unzip terraform.zip)
 
 testacc: fmtcheck bin/terraform
-	TF_ACC=1 go test $(TEST) -v $(TESTARGS) -timeout=90s
+	PATH="$(CURDIR)/bin:${PATH}" TF_ACC=1 go test $(TEST) -v $(TESTARGS) -timeout=90s
 
 # Commenting out the below because it tries to use an amd64 version of terraform that is incompatible with M1 Macs. Instead,
 # simply rely on the version of terraform that's already on your path. If you don't have terraform installed, follow instructions

--- a/mysql/provider_test.go
+++ b/mysql/provider_test.go
@@ -248,10 +248,11 @@ func testAccPreCheckSkipNotTiDBVersionMin(t *testing.T, minVersion string) {
 				return
 			}
 			if tidbSemVar.LessThan(versionMin) {
-				t.Skip("Skip on MySQL8")
+				t.Skip("Skip on TiDB (SkipNotTiDBVersionMin)")
 			}
+			return
 		}
 
-		t.Skip("Skip on MySQL8")
+		t.Skip("Skip on MySQL")
 	}
 }

--- a/mysql/resource_ti_resource_group.go
+++ b/mysql/resource_ti_resource_group.go
@@ -207,7 +207,7 @@ func getResourceGroupFromDB(db *sql.DB, name string) (*ResourceGroup, error) {
 	/*
 		Coerce types on SQL side into good types for golang
 		Burstable is a varchar(3) so we coerce to BOOLEAN
-		QUERY_LIMIT is nullable in DB, but we coerce to standard "empty" string type of "()"
+		QUERY_LIMIT is nullable in DB, but we coerce to standard "empty" string type of ""
 		Lowercase priority for less configuration variability
 	*/
 	query := `SELECT NAME, RU_PER_SEC, LOWER(PRIORITY), BURSTABLE = 'YES' as BURSTABLE, IFNULL(QUERY_LIMIT,"") FROM information_schema.resource_groups WHERE NAME = ?`

--- a/mysql/resource_ti_resource_group.go
+++ b/mysql/resource_ti_resource_group.go
@@ -53,6 +53,8 @@ var DefaultResourceGroup = ResourceGroup{
 	QueryLimit: "",
 }
 
+var ResourceGroupTiDBMinVersion = "7.5.0"
+
 func resourceTiResourceGroup() *schema.Resource {
 	return &schema.Resource{
 		CreateContext: CreateResourceGroup,

--- a/mysql/resource_ti_resource_group_test.go
+++ b/mysql/resource_ti_resource_group_test.go
@@ -1,14 +1,11 @@
 package mysql
 
-/*
-
 import (
 	"context"
 	"database/sql"
 	"errors"
 	"fmt"
 	"log"
-	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -18,6 +15,9 @@ import (
 func TestTIDBResourceGroup_basic(t *testing.T) {
 	varName := "rg100"
 	varResourceUnits := 100
+	varNewResourceUnits := 1000
+	varQueryLimit := "(EXEC_ELAPSED='15s', ACTION=COOLDOWN, WATCH=SIMILAR DURATION='10m0s')"
+	varNewQueryLimit := "(EXEC_ELAPSED='15s', ACTION=COOLDOWN, WATCH=SIMILAR DURATION='15m0s')"
 	varBurstable := true
 	varPriority := "low"
 	resourceName := "mysql_ti_resource_group.test"
@@ -26,103 +26,26 @@ func TestTIDBResourceGroup_basic(t *testing.T) {
 		PreCheck: func() {
 			testAccPreCheck(t)
 			testAccPreCheckSkipNotTiDB(t)
-			// TODO: skip if not TiDB version X (7.5.2?)
 		},
 		ProviderFactories: testAccProviderFactories,
 		CheckDestroy:      testAccResourceGroupCheckDestroy(varName),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccResourceGroupConfigBasic(varName, varResourceUnits),
+				Config: testAccResourceGroupConfigBasic(varName, varResourceUnits, varQueryLimit),
 				Check: resource.ComposeTestCheckFunc(
 					testAccResourceGroupExists(varName),
 					resource.TestCheckResourceAttr(resourceName, "name", varName),
+					resource.TestCheckResourceAttr(resourceName, "query_limit", varQueryLimit),
 				),
 			},
 			{
-				Config: testAccConfigVarConfigWithInstanceAndType(varName, varValue, varType, ""),
+				Config: testAccResourceGroupConfigFull(varName, varNewResourceUnits, varNewQueryLimit, varBurstable, varPriority),
 				Check: resource.ComposeTestCheckFunc(
-					testAccConfigVarExists(varName, varValue, varType),
+					testAccResourceGroupExists(varName),
 					resource.TestCheckResourceAttr(resourceName, "name", varName),
-				),
-			},
-			{
-				Config: testAccConfigVarConfigWithInstanceAndType(varName, varValue, varType, varInstance),
-				Check: resource.ComposeTestCheckFunc(
-					testAccConfigVarExists(varName, varValue, varType),
-					resource.TestCheckResourceAttr(resourceName, "name", varName),
-				),
-			},
-			{
-				Config:      testAccConfigVarConfigWithInstanceAndType(varName, varValue, varType, varInstance),
-				ExpectError: regexp.MustCompile("variable 'log.level' not found"),
-				Check: resource.ComposeTestCheckFunc(
-					testAccConfigVarExists(varName, varValue, "badType"),
-					resource.TestCheckResourceAttr(resourceName, "name", varName),
-				),
-			},
-			{
-				Config:      testAccConfigVarConfigWithInstanceAndType("varName", varValue, varType, varInstance),
-				ExpectError: regexp.MustCompile(".*Error: bad request to:*"),
-				Check: resource.ComposeTestCheckFunc(
-					testAccConfigVarExists(varName, varValue, varType),
-					resource.TestCheckResourceAttr(resourceName, "name", varName),
-				),
-			},
-			{
-				Config:      testAccConfigVarConfigWithInstanceAndType(varName, varValue, "varType", varInstance),
-				ExpectError: regexp.MustCompile(".*Error: expected type to be one of.*"),
-				Check: resource.ComposeTestCheckFunc(
-					testAccConfigVarExists(varName, varValue, varType),
-					resource.TestCheckResourceAttr(resourceName, "name", varName),
-				),
-			},
-			{
-				Config:      testAccConfigVarConfigWithInstanceAndType(varName, "varValue'varValue", varType, varInstance),
-				ExpectError: regexp.MustCompile(".*Error: \"value\" is badly formatted.*"),
-				Check: resource.ComposeTestCheckFunc(
-					testAccConfigVarExists(varName, varValue, varType),
-					resource.TestCheckResourceAttr(resourceName, "name", varName),
-				),
-			},
-		},
-	})
-}
-
-func TestTiKvConfigVar_basic(t *testing.T) {
-	varName := "split.qps-threshold"
-	varValue := "1000"
-	varType := "tikv"
-	varInstance := getGetInstance(varType, t)
-	resourceName := "mysql_ti_config.test"
-
-	resource.Test(t, resource.TestCase{
-		PreCheck: func() {
-			testAccPreCheck(t)
-			testAccPreCheckSkipNotTiDB(t)
-		},
-		ProviderFactories: testAccProviderFactories,
-		CheckDestroy:      testAccConfigVarCheckDestroy(varName, varType),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccConfigVarConfigBasic(varName, varValue, varType),
-				Check: resource.ComposeTestCheckFunc(
-					testAccConfigVarExists(varName, varValue, varType),
-					resource.TestCheckResourceAttr(resourceName, "name", varName),
-				),
-			},
-			{
-				Config: testAccConfigVarConfigWithInstanceAndType(varName, varValue, varType, varInstance),
-				Check: resource.ComposeTestCheckFunc(
-					testAccConfigVarExists(varName, varValue, varType),
-					resource.TestCheckResourceAttr(resourceName, "name", varName),
-				),
-			},
-			{
-				Config:      testAccConfigVarConfigWithInstanceAndType(varName, "varValue", varType, varInstance),
-				ExpectError: regexp.MustCompile(".*Error: error setting value*"),
-				Check: resource.ComposeTestCheckFunc(
-					testAccConfigVarExists(varName, "varValue", varType),
-					resource.TestCheckResourceAttr(resourceName, "name", varName),
+					resource.TestCheckResourceAttr(resourceName, "query_limit", varNewQueryLimit),
+					resource.TestCheckResourceAttr(resourceName, "burstable", fmt.Sprintf("%t", varBurstable)),
+					resource.TestCheckResourceAttr(resourceName, "priority", varPriority),
 				),
 			},
 		},
@@ -131,82 +54,47 @@ func TestTiKvConfigVar_basic(t *testing.T) {
 
 func testAccResourceGroupExists(varName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		ctx := context.Background()
-		db, err := connectToMySQL(ctx, testAccProvider.Meta().(*MySQLConfiguration))
+		rg, err := getResourceGroup(varName)
 		if err != nil {
 			return err
 		}
 
-		getResourceGroup(varName, t)
-		resName, resValue, err := testAccGetConfigVar(varName, varType, db)
-
-		if err != nil {
-			return err
+		if rg == nil {
+			return fmt.Errorf("resource group (%s) does not exist", varName)
 		}
 
-		if resValue == varValue {
-			return nil
-		}
-
-		return fmt.Errorf("variable '%s' not found. resName: %s, resValue: %s, err: %s", varName, resName, resValue, err)
+		return nil
 	}
 }
 
-type ResourceGroup struct {
-	Name          string
-	ResourceUnits int
-	Priority      string
-	Burstable     bool
-	Users         []string
-}
-
-func NewResourceGroup(name string) ResourceGroup {
-	return ResourceGroup{
+func NewResourceGroup(name string) *ResourceGroup {
+	return &ResourceGroup{
 		Name:          name,
 		ResourceUnits: 2000,
 		Priority:      "medium",
 		Burstable:     false,
+		QueryLimit:    "(EXEC_ELAPSED='15s', ACTION=COOLDOWN, WATCH=SIMILAR DURATION='10m0s')",
 	}
 }
 
-func getResourceGroup(name string) (ResourceGroup, error) {
+func getResourceGroup(name string) (*ResourceGroup, error) {
 	rg := NewResourceGroup(name)
 
 	ctx := context.Background()
 	db, err := connectToMySQL(ctx, testAccProvider.Meta().(*MySQLConfiguration))
 	if err != nil {
-		return ResourceGroup{}, err
+		return nil, err
 	}
-	query := fmt.Sprintf(`SELECT NAME, RU_PER_SEC, PRIORITY, BURSTABLE FROM information_schema.resource_groups WHERE NAME="%s";`, rg.Name)
+	query := fmt.Sprintf(`SELECT NAME, RU_PER_SEC, LOWER(PRIORITY), BURSTABLE = 'YES' as BURSTABLE, IFNULL(QUERY_LIMIT,"()") FROM information_schema.resource_groups WHERE NAME="%s";`, rg.Name)
 
 	log.Printf("[DEBUG] SQL: %s\n", query)
 
-	err = db.QueryRow(query).Scan(rg.Name, rg.ResourceUnits, rg.Priority, rg.Burstable)
+	err = db.QueryRow(query).Scan(&rg.Name, &rg.ResourceUnits, &rg.Priority, &rg.Burstable, &rg.QueryLimit)
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
-		return ResourceGroup{}, fmt.Errorf("error during get resource group (%s): %s", d.Id(), err)
+		return nil, fmt.Errorf("error during get resource group (%s): %s", rg.Name, err)
 	}
 
 	return rg, nil
-}
-
-func testAccGetResourceGroup(varName string, db *sql.DB) (string, string, error) {
-	var resType, resInstance, resName, resValue string
-
-	configQuery := "SHOW CONFIG WHERE name = ? AND type = ?"
-
-	stmt, err := db.Prepare(configQuery)
-
-	if err != nil {
-		return "nil", "nil", err
-	}
-
-	err = stmt.QueryRow(varName, varType).Scan(&resType, &resInstance, &resName, &resValue)
-
-	if err != nil && !errors.Is(err, sql.ErrNoRows) {
-		return "nil", "nil", err
-	}
-
-	return resName, resValue, nil
 }
 
 func testAccResourceGroupCheckDestroy(varName string) resource.TestCheckFunc {
@@ -215,23 +103,24 @@ func testAccResourceGroupCheckDestroy(varName string) resource.TestCheckFunc {
 	}
 }
 
-func testAccResourceGroupConfigBasic(varName string, varResourceUnits int) string {
+func testAccResourceGroupConfigBasic(varName string, varResourceUnits int, varQueryLimit string) string {
 	return fmt.Sprintf(`
 resource "mysql_ti_resource_group" "test" {
 		name = "%s"
-		resource_units = "%s"
+		resource_units = %d
+		query_limit = "%s"
 }
-`, varName, varResourceUnits)
+`, varName, varResourceUnits, varQueryLimit)
 }
 
-func testAccResourceGroupConfigFull(varName string, varResourceUnits int, varPriority string, varBurstable bool, users []string) string {
+func testAccResourceGroupConfigFull(varName string, varResourceUnits int, varQueryLimit string, varBurstable bool, varPriority string) string {
 	return fmt.Sprintf(`
 resource "mysql_ti_resource_group" "test" {
 		name = "%s"
-		resource_units = "%s"
+		resource_units = %d
 		priority = "%s"
-		burstable = %s
+		burstable = %t
+		query_limit = "%s"
 }
-`, varName, varResourceUnits, varPriority, varBurstable)
+`, varName, varResourceUnits, varPriority, varBurstable, varQueryLimit)
 }
-*/

--- a/mysql/resource_ti_resource_group_test.go
+++ b/mysql/resource_ti_resource_group_test.go
@@ -26,6 +26,7 @@ func TestTIDBResourceGroup_basic(t *testing.T) {
 		PreCheck: func() {
 			testAccPreCheck(t)
 			testAccPreCheckSkipNotTiDB(t)
+			testAccPreCheckSkipNotTiDBVersionMin(t, "7.5.0")
 		},
 		ProviderFactories: testAccProviderFactories,
 		CheckDestroy:      testAccResourceGroupCheckDestroy(varName),

--- a/mysql/resource_ti_resource_group_test.go
+++ b/mysql/resource_ti_resource_group_test.go
@@ -26,7 +26,7 @@ func TestTIDBResourceGroup_basic(t *testing.T) {
 		PreCheck: func() {
 			testAccPreCheck(t)
 			testAccPreCheckSkipNotTiDB(t)
-			testAccPreCheckSkipNotTiDBVersionMin(t, "7.5.0")
+			testAccPreCheckSkipNotTiDBVersionMin(t, ResourceGroupTiDBMinVersion)
 		},
 		ProviderFactories: testAccProviderFactories,
 		CheckDestroy:      testAccResourceGroupCheckDestroy(varName),

--- a/mysql/resource_ti_resource_group_test.go
+++ b/mysql/resource_ti_resource_group_test.go
@@ -16,8 +16,8 @@ func TestTIDBResourceGroup_basic(t *testing.T) {
 	varName := "rg100"
 	varResourceUnits := 100
 	varNewResourceUnits := 1000
-	varQueryLimit := "(EXEC_ELAPSED='15s', ACTION=COOLDOWN, WATCH=SIMILAR DURATION='10m0s')"
-	varNewQueryLimit := "(EXEC_ELAPSED='15s', ACTION=COOLDOWN, WATCH=SIMILAR DURATION='15m0s')"
+	varQueryLimit := ""
+	varNewQueryLimit := "EXEC_ELAPSED='15s', ACTION=COOLDOWN, WATCH=SIMILAR DURATION='10m0s'"
 	varBurstable := true
 	varPriority := "low"
 	resourceName := "mysql_ti_resource_group.test"
@@ -73,7 +73,7 @@ func NewResourceGroup(name string) *ResourceGroup {
 		ResourceUnits: 2000,
 		Priority:      "medium",
 		Burstable:     false,
-		QueryLimit:    "(EXEC_ELAPSED='15s', ACTION=COOLDOWN, WATCH=SIMILAR DURATION='10m0s')",
+		QueryLimit:    "EXEC_ELAPSED='15s', ACTION=COOLDOWN, WATCH=SIMILAR DURATION='10m0s'",
 	}
 }
 
@@ -85,7 +85,7 @@ func getResourceGroup(name string) (*ResourceGroup, error) {
 	if err != nil {
 		return nil, err
 	}
-	query := fmt.Sprintf(`SELECT NAME, RU_PER_SEC, LOWER(PRIORITY), BURSTABLE = 'YES' as BURSTABLE, IFNULL(QUERY_LIMIT,"()") FROM information_schema.resource_groups WHERE NAME="%s";`, rg.Name)
+	query := fmt.Sprintf(`SELECT NAME, RU_PER_SEC, LOWER(PRIORITY), BURSTABLE = 'YES' as BURSTABLE, IFNULL(QUERY_LIMIT, "") FROM information_schema.resource_groups WHERE NAME="%s";`, rg.Name)
 
 	log.Printf("[DEBUG] SQL: %s\n", query)
 

--- a/mysql/resource_ti_resource_group_user_assignment.go
+++ b/mysql/resource_ti_resource_group_user_assignment.go
@@ -68,7 +68,6 @@ func CreateOrUpdateResourceGroupUser(ctx context.Context, d *schema.ResourceData
 		return diag.Errorf("error attaching user (%s) to resource group (%s): %s", user, resourceGroup, err)
 	}
 
-	// TODO: relevant?
 	db.QueryRowContext(ctx, "SHOW WARNINGS").Scan(&warnLevel, &warnCode, &warnMessage)
 	if warnCode != 0 {
 		d.SetId("")
@@ -108,7 +107,6 @@ func ReadResourceGroupUser(ctx context.Context, d *schema.ResourceData, meta int
 
 func DeleteResourceGroupUser(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	user := d.Get("user").(string)
-	// TODO: should we re-assert that it's part of the expected resourceGroup first? I think no bc plan should read it
 
 	db, err := getDatabaseFromMeta(ctx, meta)
 	if err != nil {

--- a/mysql/resource_ti_resource_group_user_assignment.go
+++ b/mysql/resource_ti_resource_group_user_assignment.go
@@ -126,7 +126,7 @@ func DeleteResourceGroupUser(ctx context.Context, d *schema.ResourceData, meta i
 }
 
 func readUserFromDB(db *sql.DB, name string) (string, string, error) {
-	selectUsersQuery := `SELECT USER, IFNULL(JSON_EXTRACT(User_attributes, "$.resource_group"), "") as resource_group FROM mysql.user WHERE USER = ?`
+	selectUsersQuery := `SELECT USER, JSON_UNQUOTE(IFNULL(JSON_EXTRACT(User_attributes, "$.resource_group"), "")) as resource_group FROM mysql.user WHERE USER = ?`
 	row := db.QueryRow(selectUsersQuery, name)
 
 	var user, resourceGroup string

--- a/mysql/resource_ti_resource_group_user_assignment_test.go
+++ b/mysql/resource_ti_resource_group_user_assignment_test.go
@@ -1,0 +1,88 @@
+package mysql
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestTIDBResourceGroupUserAssignment_basic(t *testing.T) {
+	varUsername := "tidb-jdoe"
+	varName := "rg100"
+	varResourceUnits := 100
+	varQueryLimit := "()"
+	resourceGroupAssignmentResourceName := "mysql_ti_resource_group_user_assignment.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckSkipNotTiDB(t)
+		},
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccResourceGroupUserAssignmentCheckDestroy(varName),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceGroupUserAssignmentBasic(varUsername, varName, varResourceUnits, varQueryLimit),
+				Check: resource.ComposeTestCheckFunc(
+					testAccResourceGroupUserAssignmentExists(varUsername, varName),
+					resource.TestCheckResourceAttr(resourceGroupAssignmentResourceName, "user", varUsername),
+					resource.TestCheckResourceAttr(resourceGroupAssignmentResourceName, "resource_group", varName),
+				),
+			},
+		},
+	})
+}
+
+func testAccResourceGroupUserAssignmentExists(username string, resourceGroupName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		ctx := context.Background()
+		db, err := connectToMySQL(ctx, testAccProvider.Meta().(*MySQLConfiguration))
+		if err != nil {
+			return err
+		}
+
+		user, resourceGroup, err := readUserFromDB(db, username)
+		if err != nil {
+			return err
+		}
+
+		if user != username {
+			return fmt.Errorf("user (%s) does not exist", username)
+		}
+
+		if resourceGroup != resourceGroupName {
+			return fmt.Errorf("resource group (%s) is not assigned to user (%s)", resourceGroupName, username)
+		}
+
+		return nil
+	}
+}
+
+func testAccResourceGroupUserAssignmentCheckDestroy(varName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		return nil
+	}
+}
+
+func testAccResourceGroupUserAssignmentBasic(varUsername string, varResourceGroupName string, varResourceUnits int, varQueryLimit string) string {
+	return fmt.Sprintf(`
+resource "mysql_user" "test" {
+	user = "%s"
+	host = "%%"
+}
+
+resource "mysql_ti_resource_group" "test" {
+	name = "%s"
+	resource_units = %d
+	query_limit = "%s"
+}
+
+resource "mysql_ti_resource_group_user_assignment" "test" {
+	user = "${mysql_user.test.user}"
+	resource_group = "${mysql_ti_resource_group.test.name}"
+}
+`, varUsername, varResourceGroupName, varResourceUnits, varQueryLimit)
+}

--- a/mysql/resource_ti_resource_group_user_assignment_test.go
+++ b/mysql/resource_ti_resource_group_user_assignment_test.go
@@ -20,6 +20,7 @@ func TestTIDBResourceGroupUserAssignment_basic(t *testing.T) {
 		PreCheck: func() {
 			testAccPreCheck(t)
 			testAccPreCheckSkipNotTiDB(t)
+			testAccPreCheckSkipNotTiDBVersionMin(t, ResourceGroupTiDBMinVersion)
 		},
 		ProviderFactories: testAccProviderFactories,
 		CheckDestroy:      testAccResourceGroupUserAssignmentCheckDestroy(varName),

--- a/mysql/resource_ti_resource_group_user_assignment_test.go
+++ b/mysql/resource_ti_resource_group_user_assignment_test.go
@@ -13,7 +13,7 @@ func TestTIDBResourceGroupUserAssignment_basic(t *testing.T) {
 	varUsername := "tidb-jdoe"
 	varName := "rg100"
 	varResourceUnits := 100
-	varQueryLimit := "()"
+	varQueryLimit := ""
 	resourceGroupAssignmentResourceName := "mysql_ti_resource_group_user_assignment.test"
 
 	resource.Test(t, resource.TestCase{

--- a/scripts/tidb-test-cluster.sh
+++ b/scripts/tidb-test-cluster.sh
@@ -16,7 +16,7 @@ SCRIPT_INIT=false
 DOCKER_NETWORK="mysql_provider_test_network"
 RUNNING_CONTAINERS=""
 export MYSQL_PORT=${MYSQL_PORT:-4000}
-export TAG_VERSION="v${MYSQL_VERSION:-6.1.0}"
+export TAG_VERSION="v${MYSQL_VERSION:-7.5.1}"
 
 # Sanity checks
 if [ -z "$DOCKER" ]; then
@@ -36,7 +36,7 @@ Usage:
   --init ^ Init TiDB cluster
   --destroy ^ Destroy resources
   --port <MYSQL_PORT> ^ TiDB Listen port (default: 4000)
-  --version <MYSQL_VERSION> ^ TiDB version (default: 6.1.0)
+  --version <MYSQL_VERSION> ^ TiDB version (default: 7.5.1)
   -h|--help ^ Displays this help
 EOF
 }


### PR DESCRIPTION
This fixes the following drift:
1. Resource group name would always be in quotes when pulled from the DB. This PR removes the quotes.
2. Query Limit would always be missing `()` parentheses when pulled from the DB. This PR standardizes around the query_limit inside the parentheses. A breaking change is that we expect NO parenthesis to be passed in for the query_limit from now on. Instead, we will wrap the query_limit inside parentheses in the actual query rather than rely on the query_limit string being wrapped in parentheses by the caller.

I also got basic tidb tests working and tested the above changes using `make testtidb7.5.1`