### PR TITLE
Support placement_policy resource and database configuration

### DIFF
--- a/mysql/provider.go
+++ b/mysql/provider.go
@@ -256,6 +256,7 @@ func Provider() *schema.Provider {
 			"mysql_ti_config":         resourceTiConfigVariable(),
 			"mysql_ti_resource_group": resourceTiResourceGroup(),
 			"mysql_ti_resource_group_user_assignment": resourceTiResourceGroupUserAssignment(),
+			"mysql_ti_placement_policy":               resourceTiPlacementPolicy(),
 			"mysql_rds_config":                        resourceRDSConfig(),
 			"mysql_default_roles":                     resourceDefaultRoles(),
 		},

--- a/mysql/resource_database.go
+++ b/mysql/resource_database.go
@@ -65,7 +65,10 @@ func CreateDatabase(ctx context.Context, d *schema.ResourceData, meta interface{
 		return diag.FromErr(err)
 	}
 
-	stmtSQL := databaseConfigSQL("CREATE", d)
+	stmtSQL, err := databaseConfigSQL("CREATE", d, db)
+	if err != nil {
+		return diag.Errorf("failed constructing create SQL statement: %v", err)
+	}
 	log.Println("[DEBUG] Executing statement:", stmtSQL)
 
 	_, err = db.ExecContext(ctx, stmtSQL)
@@ -84,7 +87,10 @@ func UpdateDatabase(ctx context.Context, d *schema.ResourceData, meta interface{
 		return diag.FromErr(err)
 	}
 
-	stmtSQL := databaseConfigSQL("ALTER", d)
+	stmtSQL, err := databaseConfigSQL("ALTER", d, db)
+	if err != nil {
+		return diag.Errorf("failed constructing update SQL statement: %v", err)
+	}
 	log.Println("[DEBUG] Executing statement:", stmtSQL)
 
 	_, err = db.ExecContext(ctx, stmtSQL)
@@ -186,7 +192,7 @@ func DeleteDatabase(ctx context.Context, d *schema.ResourceData, meta interface{
 	return nil
 }
 
-func databaseConfigSQL(verb string, d *schema.ResourceData) string {
+func databaseConfigSQL(verb string, d *schema.ResourceData, db *sql.DB) (string, error) {
 	name := d.Get("name").(string)
 	defaultCharset := d.Get("default_character_set").(string)
 	defaultCollation := d.Get("default_collation").(string)
@@ -202,10 +208,20 @@ func databaseConfigSQL(verb string, d *schema.ResourceData) string {
 	if defaultCollation != "" {
 		defaultCollationClause = defaultCollateKeyword + quoteIdentifier(defaultCollation)
 	}
-	if placementPolicy != "" {
-		placementPolicyClause = placementPolicyKeyword + quoteIdentifier(placementPolicy)
-	} else {
-		placementPolicyClause = placementPolicyKeyword + quoteIdentifier(placementPolicyDefault)
+
+	isTiDB, _, _, err := serverTiDB(db)
+	if err != nil {
+		return "", err
+	}
+
+	if isTiDB {
+		if placementPolicy != "" {
+			placementPolicyClause = placementPolicyKeyword + quoteIdentifier(placementPolicy)
+		} else {
+			placementPolicyClause = placementPolicyKeyword + quoteIdentifier(placementPolicyDefault)
+		}
+	} else if placementPolicy != "" {
+		return fmt.Errorf("placement_policy is only supported for TiDB")
 	}
 
 	return fmt.Sprintf(

--- a/mysql/resource_database.go
+++ b/mysql/resource_database.go
@@ -221,7 +221,7 @@ func databaseConfigSQL(verb string, d *schema.ResourceData, db *sql.DB) (string,
 			placementPolicyClause = placementPolicyKeyword + quoteIdentifier(placementPolicyDefault)
 		}
 	} else if placementPolicy != "" {
-		return fmt.Errorf("placement_policy is only supported for TiDB")
+		return "", fmt.Errorf("placement_policy is only supported for TiDB")
 	}
 
 	return fmt.Sprintf(
@@ -231,7 +231,7 @@ func databaseConfigSQL(verb string, d *schema.ResourceData, db *sql.DB) (string,
 		defaultCharsetClause,
 		defaultCollationClause,
 		placementPolicyClause,
-	)
+	), nil
 }
 
 func extractIdentAfter(sql string, keyword string) string {

--- a/mysql/resource_ti_placement_policy.go
+++ b/mysql/resource_ti_placement_policy.go
@@ -1,0 +1,266 @@
+package mysql
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"log"
+	"regexp"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+var CreatePlacementPolicySQLPrefix = "CREATE PLACEMENT POLICY IF NOT EXISTS"
+var UpdatePlacementPolicySQLPrefix = "ALTER PLACEMENT POLICY"
+var BracketsRegex = regexp.MustCompile("^\\[(.+)\\]$")
+
+type PlacementPolicy struct {
+	Name          string
+	PrimaryRegion string
+	Regions       []string
+	Constraints   []string
+}
+
+func (pp *PlacementPolicy) buildSQLQuery(prefix string) string {
+	query := []string{}
+
+	baseQuery := fmt.Sprintf(
+		"%s %s",
+		prefix,
+		pp.Name,
+	)
+
+	query = append(query, baseQuery)
+
+	if pp.PrimaryRegion != "" {
+		primaryRegionClause := fmt.Sprintf(`PRIMARY_REGION="%s"`, pp.PrimaryRegion)
+		query = append(query, primaryRegionClause)
+	}
+
+	if len(pp.Regions) > 0 {
+		regionsClause := fmt.Sprintf(`REGIONS="%s"`, strings.Join(pp.Regions, ","))
+		query = append(query, regionsClause)
+	}
+
+	if len(pp.Constraints) > 0 {
+		constraintsClause := fmt.Sprintf(`CONSTRAINTS="[%s]"`, strings.Join(pp.Constraints, ","))
+		query = append(query, constraintsClause)
+	} else {
+		// Allow for empty constraints to be set in order to represent a
+		// placement policy without constraints.
+		query = append(query, `CONSTRAINTS=""`)
+	}
+
+	query = append(query, ";")
+
+	ctx := context.Background()
+	tflog.SetField(ctx, "sql", query)
+	tflog.Debug(ctx, `buildSQLQuery`)
+
+	return strings.Join(query, " ")
+}
+
+func resourceTiPlacementPolicy() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: CreatePlacementPolicy,
+		ReadContext:   ReadPlacementPolicy,
+		UpdateContext: UpdatePlacementPolicy,
+		DeleteContext: DeletePlacementPolicy,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"primary_region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: false,
+				Default:  "",
+			},
+			"regions": {
+				Type:     schema.TypeList,
+				Optional: true,
+				ForceNew: false,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"constraints": {
+				Type:     schema.TypeList,
+				Optional: true,
+				ForceNew: false,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+		},
+	}
+}
+
+func CreatePlacementPolicy(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	db, err := getDatabaseFromMeta(ctx, meta)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	pp := NewPlacementPolicyFromResourceData(d)
+
+	var warnLevel, warnMessage string
+	var warnCode int = 0
+
+	query := pp.buildSQLQuery(CreatePlacementPolicySQLPrefix)
+	tflog.SetField(ctx, "query", query)
+	tflog.Debug(ctx, "SQL")
+
+	_, err = db.ExecContext(ctx, query)
+	if err != nil {
+		return diag.Errorf("error creating placement policy (%s): %s", pp.Name, err)
+	}
+
+	db.QueryRowContext(ctx, "SHOW WARNINGS").Scan(&warnLevel, &warnCode, &warnMessage)
+	if warnCode != 0 {
+		return diag.Errorf("error setting value: %+v Error: %s", pp, warnMessage)
+	}
+
+	d.SetId(pp.Name)
+
+	return nil
+}
+
+func UpdatePlacementPolicy(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	db, err := getDatabaseFromMeta(ctx, meta)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	pp := NewPlacementPolicyFromResourceData(d)
+
+	var warnLevel, warnMessage string
+	var warnCode int = 0
+
+	query := pp.buildSQLQuery(UpdatePlacementPolicySQLPrefix)
+
+	tflog.SetField(ctx, "query", query)
+	tflog.Debug(ctx, "SQL")
+
+	_, err = db.ExecContext(ctx, query)
+	if err != nil {
+		return diag.Errorf("error altering placement policy (%s): %s", pp.Name, err)
+	}
+
+	db.QueryRowContext(ctx, "SHOW WARNINGS").Scan(&warnLevel, &warnCode, &warnMessage)
+	if warnCode != 0 {
+		return diag.Errorf("error altering placement policy (%s) %s", pp.Name, warnMessage)
+	}
+
+	d.SetId(pp.Name)
+
+	return nil
+}
+
+func ReadPlacementPolicy(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	db, err := getDatabaseFromMeta(ctx, meta)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	pp, err := getPlacementPolicyFromDB(db, d.Id())
+	if err != nil {
+		d.SetId("")
+		return diag.Errorf("error during get placement policy (%s): %s", d.Id(), err)
+	}
+
+	// If we're not able to find the placement policy, assume that there's terraform
+	// diff and allow terraform to recreate it instead of throwing an error.
+	if pp == nil {
+		d.SetId("")
+		return nil
+	}
+
+	setPlacementPolicyOnResourceData(*pp, d)
+	return nil
+}
+
+func DeletePlacementPolicy(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	name := d.Get("name").(string)
+
+	db, err := getDatabaseFromMeta(ctx, meta)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	deleteQuery := fmt.Sprintf("DROP PLACEMENT POLICY IF EXISTS %s", name)
+	_, err = db.Exec(deleteQuery)
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return diag.Errorf("error during drop placement policy (%s): %s", d.Id(), err)
+	}
+
+	d.SetId("")
+	return nil
+}
+
+func NewPlacementPolicyFromResourceData(d *schema.ResourceData) PlacementPolicy {
+	// Can I cast this directly to []string?
+	regionsAny := d.Get("regions").([]any)
+	constraintsAny := d.Get("constraints").([]any)
+	regions := []string{}
+	constraints := []string{}
+
+	for _, regionAny := range regionsAny {
+		regions = append(regions, regionAny.(string))
+	}
+
+	for _, constraintAny := range constraintsAny {
+		constraints = append(constraints, constraintAny.(string))
+	}
+
+	return PlacementPolicy{
+		Name:          d.Get("name").(string),
+		PrimaryRegion: d.Get("primary_region").(string),
+		Regions:       regions,
+		Constraints:   constraints,
+	}
+}
+
+func getPlacementPolicyFromDB(db *sql.DB, name string) (*PlacementPolicy, error) {
+	pp := PlacementPolicy{Name: name}
+
+	query := `SELECT POLICY_NAME, PRIMARY_REGION, REGIONS, CONSTRAINTS FROM information_schema.placement_policies where POLICY_NAME = ?`
+
+	ctx := context.Background()
+	tflog.SetField(ctx, "query", query)
+	tflog.Debug(ctx, "getPlacementPolicyFromDB")
+
+	var regionsHolder string
+	var constraintsHolder string
+
+	err := db.QueryRow(query, name).Scan(&pp.Name, &pp.PrimaryRegion, &regionsHolder, &constraintsHolder)
+	if errors.Is(err, sql.ErrNoRows) {
+		log.Printf("[DEBUG] placement policy doesn't exist (%s): %s", name, err)
+		return nil, nil
+	} else if err != nil {
+		return nil, fmt.Errorf("error during get placement policy (%s): %s", name, err)
+	}
+
+	if regionsHolder != "" {
+		pp.Regions = strings.Split(regionsHolder, ",")
+	}
+
+	constraintMatches := BracketsRegex.FindStringSubmatch(constraintsHolder)
+	if len(constraintMatches) >= 2 {
+		pp.Constraints = strings.Split(constraintMatches[1], ",")
+	}
+
+	return &pp, nil
+}
+
+func setPlacementPolicyOnResourceData(pp PlacementPolicy, d *schema.ResourceData) {
+	d.Set("name", pp.Name)
+	d.Set("primary_region", pp.PrimaryRegion)
+	d.Set("regions", pp.Regions)
+	d.Set("constraints", pp.Constraints)
+}

--- a/mysql/resource_ti_placement_policy.go
+++ b/mysql/resource_ti_placement_policy.go
@@ -204,7 +204,6 @@ func DeletePlacementPolicy(ctx context.Context, d *schema.ResourceData, meta int
 }
 
 func NewPlacementPolicyFromResourceData(d *schema.ResourceData) PlacementPolicy {
-	// Can I cast this directly to []string?
 	regionsAny := d.Get("regions").([]any)
 	constraintsAny := d.Get("constraints").([]any)
 	regions := []string{}

--- a/mysql/resource_ti_placement_policy_test.go
+++ b/mysql/resource_ti_placement_policy_test.go
@@ -1,0 +1,94 @@
+package mysql
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestTIDBPlacementPolicy_basic(t *testing.T) {
+	resourceName := "mysql_ti_placement_policy.test"
+	varName := "test_policy"
+	varPrimaryRegion := ""
+	varRegions := `[]`
+	varConstraints := `["+key=value"]`
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckSkipNotTiDB(t)
+		},
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccPlacementPolicyCheckDestroy(varName),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPlacementPolicyConfigBasic(varName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccPlacementPolicyExists(varName),
+					resource.TestCheckResourceAttr(resourceName, "name", varName),
+				),
+			},
+			{
+				Config: testAccPlacementPolicyConfigFull(varName, varPrimaryRegion, varRegions, varConstraints),
+				Check: resource.ComposeTestCheckFunc(
+					testAccPlacementPolicyExists(varName),
+					resource.TestCheckResourceAttr(resourceName, "primary_region", varPrimaryRegion),
+					resource.TestCheckResourceAttr(resourceName, "constraints.0", "+key=value"),
+				),
+			},
+		},
+	})
+}
+
+func testAccPlacementPolicyExists(varName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rg, err := getPlacementPolicy(varName)
+		if err != nil {
+			return err
+		}
+
+		if rg == nil {
+			return fmt.Errorf("placement policy (%s) does not exist", varName)
+		}
+
+		return nil
+	}
+}
+
+func getPlacementPolicy(name string) (*PlacementPolicy, error) {
+	ctx := context.Background()
+	db, err := connectToMySQL(ctx, testAccProvider.Meta().(*MySQLConfiguration))
+	if err != nil {
+		return nil, err
+	}
+
+	return getPlacementPolicyFromDB(db, name)
+}
+
+func testAccPlacementPolicyCheckDestroy(varName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		return nil
+	}
+}
+
+func testAccPlacementPolicyConfigBasic(varName string) string {
+	return fmt.Sprintf(`
+resource "mysql_ti_placement_policy" "test" {
+  name = "%s"
+}
+`, varName)
+}
+
+func testAccPlacementPolicyConfigFull(varName string, varPrimaryRegion string, varRegions string, varConstraints string) string {
+	return fmt.Sprintf(`
+resource "mysql_ti_placement_policy" "test" {
+		name = "%s"
+		primary_region = "%s"
+		regions = %s
+		constraints = %s
+}
+`, varName, varPrimaryRegion, varRegions, varConstraints)
+}


### PR DESCRIPTION
Supports creating a placement policy and adding it to a database:

```
resource "mysql_ti_placement_policy" "test" {
    name = "%s"
    primary_region = "%s"
    regions = %s
    constraints = %s
}

resource "mysql_database" "test" {
    name = "%s"
    default_character_set = "%s"
    default_collation = "%s"
    placement_policy = mysql_ti_placement_policy.test.name
}
```