### PR TITLE
Fix bug that prevented removal of query limits

### DIFF
--- a/mysql/resource_ti_resource_group.go
+++ b/mysql/resource_ti_resource_group.go
@@ -33,7 +33,9 @@ func (rg *ResourceGroup) buildSQLQuery(prefix string) string {
 
 	query = append(query, fmt.Sprintf(`PRIORITY = %s`, rg.Priority))
 
-	if rg.QueryLimit != DefaultResourceGroup.QueryLimit {
+	if rg.QueryLimit == "" {
+		query = append(query, fmt.Sprintf(`QUERY_LIMIT=NULL`))
+	} else {
 		query = append(query, fmt.Sprintf(`QUERY_LIMIT=(%s)`, rg.QueryLimit))
 	}
 


### PR DESCRIPTION
There was previously a bug that prevented query_limits from being removed if you pass in an empty string. This PR should fix this bug.

Tested with `make testtidb7.5.1 `