### PR TITLE
Convert make release to Go script with improved UI

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,10 +13,10 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ master ]
+    branches: [ "r3.0.62", "3.0.62" ]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ master ]
+    branches: [ "r3.0.62", "3.0.62" ]
   schedule:
     - cron: '20 21 * * 3'
 
@@ -42,7 +42,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -56,7 +56,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+      uses: github/codeql-action/autobuild@v3
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
@@ -69,4 +69,4 @@ jobs:
     #   ./location_of_script_within_repo/buildscript.sh
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v3

--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,7 @@ help: ## Show this help message
 	@echo ''
 	@echo 'Examples:'
 	@echo '  make build              Build the provider'
+	@echo '  make release            Create a release PR branch (PR-based workflow)'
 	@echo '  make testversion8.0    Run tests against MySQL 8.0'
 	@echo '  make testtidb8.5.3     Run tests against TiDB 8.5.3'
 	@echo '  make acceptance        Run all acceptance tests'
@@ -241,7 +242,7 @@ tag: ## Create git tag from VERSION file
 	@echo git tag -a $(shell cat VERSION) -m $(shell cat VERSION)
 	@git tag -a v$(shell cat VERSION) -m v$(shell cat VERSION)
 
-release: ## Create a release (tag, build, and optionally push to GitHub)
+release-local: ## Create a release locally (for testing - use 'make release' for PR-based workflow)
 	@VERSION=$$(cat VERSION); \
 	TAG="v$$VERSION"; \
 	echo "Checking if tag $$TAG already exists..."; \
@@ -347,4 +348,7 @@ release: ## Create a release (tag, build, and optionally push to GitHub)
 	echo ""; \
 	echo "Release complete! Tag $$TAG has been pushed to GitHub."
 
-.PHONY: help build test testacc vet fmt fmtcheck errcheck vendor-status test-compile website website-test tag format-tag release
+release: ## Create a release PR branch (tag, push branch and tag, then create PR to merge to default branch)
+	@go run scripts/make-release.go
+
+.PHONY: help build test testacc vet fmt fmtcheck errcheck vendor-status test-compile website website-test tag format-tag release release-local

--- a/Makefile
+++ b/Makefile
@@ -182,7 +182,7 @@ testmariadb: ## Run tests against MariaDB version (set MYSQL_VERSION)
 
 vet: ## Run go vet
 	@echo "go vet ."
-	@go vet $$(go list ./... | grep -v vendor/) ; if [ $$? -eq 1 ]; then \
+	@go vet $$(go list ./... | grep -v vendor/ | grep -v '/scripts') ; if [ $$? -eq 1 ]; then \
 		echo ""; \
 		echo "Vet found suspicious constructs. Please check the reported constructs"; \
 		echo "and fix them if necessary before submitting the code for review."; \

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ The `make release` command implements a PR-based workflow:
 
 3. **Version File Update**: If a new version was determined, the `VERSION` file is automatically updated with the new version number.
 
-4. **Default Branch Update**: Fetches and updates the default branch (`3.0.62`) to ensure the release branch is created from the latest code.
+4. **Default Branch Update**: Fetches and updates the default branch (`r3.0.62`) to ensure the release branch is created from the latest code.
 
 5. **Release Branch Creation**: Creates a new branch named `release/v{VERSION}` (e.g., `release/v3.0.62007`) from the updated default branch.
 
@@ -86,7 +86,7 @@ The `make release` command implements a PR-based workflow:
    - Signs the checksum file with GPG (configured in CI/CD)
    - Creates a GitHub release
 
-10. **Pull Request**: Create a pull request from the release branch (`release/v{VERSION}`) to the default branch (`3.0.62`).
+10. **Pull Request**: Create a pull request from the release branch (`release/v{VERSION}`) to the default branch (`r3.0.62`).
 
 11. **Merge**: After CI completes successfully, merge the PR to complete the release.
 
@@ -100,15 +100,15 @@ make release
 
 The process will guide you through each step with clear prompts. You can cancel at any point if needed.
 
-**Note**: The command automatically updates the default branch (`3.0.62`) before creating the release branch, so you can run it from any branch. The release branch will always be created from the latest version of the default branch.
+**Note**: The command automatically updates the default branch (`r3.0.62`) before creating the release branch, so you can run it from any branch. The release branch will always be created from the latest version of the default branch.
 
 ### Example Release Session
 
 ```bash
 $ make release
-Updating default branch (3.0.62) before creating release branch...
+Updating default branch (r3.0.62) before creating release branch...
 Fetching latest changes from origin...
-Checking out default branch 3.0.62...
+Checking out default branch r3.0.62...
 Default branch updated successfully.
 Checking if tag v3.0.62006 already exists...
 Tag v3.0.62006 already exists!
@@ -126,13 +126,13 @@ Release Summary:
   Tag: v3.0.62007
   Version: 3.0.62007
   Release Branch: release/v3.0.62007
-  Target Branch: 3.0.62
+  Target Branch: r3.0.62
 =========================================
 
 Do you want to create release branch and tag v3.0.62007? (yes/no): yes
 
-Creating release branch release/v3.0.62007 from updated default branch (3.0.62)...
-Release branch created from updated 3.0.62.
+Creating release branch release/v3.0.62007 from updated default branch (r3.0.62)...
+Release branch created from updated r3.0.62.
 
 Committing VERSION file change...
 VERSION file change committed.
@@ -151,10 +151,10 @@ Next steps:
 1. GitHub Actions will automatically build the release when the tag is pushed.
 2. Create a pull request:
    - Source: release/v3.0.62007
-   - Target: 3.0.62
-   - URL: https://github.com/zph/terraform-provider-mysql/compare/3.0.62...release/v3.0.62007
+   - Target: r3.0.62
+   - URL: https://github.com/zph/terraform-provider-mysql/compare/r3.0.62...release/v3.0.62007
 3. Wait for CI to complete the release build.
-4. Review and merge the PR into 3.0.62 to complete the release.
+4. Review and merge the PR into r3.0.62 to complete the release.
 
 To switch back to your previous branch, run:
   git checkout your-feature-branch

--- a/README.md
+++ b/README.md
@@ -40,36 +40,25 @@ https://www.linkedin.com/in/zph/ that appropriate safeguards are being taken.
 
 ## Release Process
 
-The release process is automated through the `make release` command, which handles tag management, version file updates, GitHub releases, and pushing changes.
+The release process uses a PR-based workflow through the `make release` command. This creates a release branch, tags the release, and pushes both to GitHub. GitHub Actions then automatically builds and creates the release when the tag is pushed.
 
 ### Prerequisites
 
 Before running the release process, ensure you have the following set up:
 
-1. **GPG Key for Signing**: A GPG key must be configured for signing release artifacts.
-   - Set the `GPG_FINGERPRINT` environment variable to your GPG key fingerprint:
-     ```bash
-     export GPG_FINGERPRINT="your-gpg-key-fingerprint"
-     ```
-   - To find your GPG key fingerprint:
-     ```bash
-     gpg --list-secret-keys --keyid-format LONG
-     ```
-   - The fingerprint is the long string after the key type (e.g., `RSA 4096/ABC123DEF456...`)
-
-2. **GitHub Authentication**: You need authentication configured for pushing to GitHub.
+1. **GitHub Authentication**: You need authentication configured for pushing to GitHub.
    - Either configure SSH keys for git push, or
    - Set up a GitHub Personal Access Token with appropriate permissions
-   - goreleaser will use `GITHUB_TOKEN` environment variable if set, otherwise it will use git credentials
 
-3. **Required Tools**:
-   - `goreleaser` - Install from https://goreleaser.com/install/
+2. **Required Tools**:
    - `git` - For version control operations
    - `make` - For running the release command
 
-### Release Workflow
+**Note**: GPG signing and release building are handled automatically by GitHub Actions CI/CD. You don't need to configure GPG keys or goreleaser locally for the PR-based workflow.
 
-The `make release` command performs the following steps:
+### Release Workflow (PR-Based)
+
+The `make release` command implements a PR-based workflow:
 
 1. **Version Check**: Reads the current version from the `VERSION` file and checks if a tag for that version already exists.
 
@@ -80,27 +69,30 @@ The `make release` command performs the following steps:
 
 3. **Version File Update**: If a new version was determined, the `VERSION` file is automatically updated with the new version number.
 
-4. **Confirmation Prompts**: The process includes interactive confirmations at key steps:
-   - Confirmation to create and tag the release
-   - Confirmation to deploy as a GitHub release
-   - Confirmation to push tags and commits to GitHub
+4. **Default Branch Update**: Fetches and updates the default branch (`3.0.62`) to ensure the release branch is created from the latest code.
 
-5. **Tag Creation**: Creates an annotated git tag with the version number.
+5. **Release Branch Creation**: Creates a new branch named `release/v{VERSION}` (e.g., `release/v3.0.62007`) from the updated default branch.
 
-6. **Version File Commit**: If the `VERSION` file was modified, it commits the change with message "Update VERSION to {version}".
+6. **Version File Commit**: If the `VERSION` file was modified, it commits the change on the release branch with message "Update VERSION to {version}".
 
-7. **GitHub Release**: Uses `goreleaser` to:
-   - Build binaries for all supported platforms (Linux, macOS, Windows, FreeBSD)
-   - Create archives (zip files) for each platform/architecture combination
-   - Generate SHA256 checksums
-   - Sign the checksum file with your GPG key
-   - Create a draft GitHub release (you can publish it manually after review)
+7. **Tag Creation**: Creates an annotated git tag with the version number on the release branch.
 
-8. **Push to GitHub**: Pushes the tag and commits to the remote repository.
+8. **Push to GitHub**: Pushes both the release branch and tag to GitHub.
+
+9. **GitHub Actions**: When the tag is pushed, GitHub Actions automatically:
+   - Builds binaries for all supported platforms (Linux, macOS, Windows, FreeBSD)
+   - Creates archives (zip files) for each platform/architecture combination
+   - Generates SHA256 checksums
+   - Signs the checksum file with GPG (configured in CI/CD)
+   - Creates a GitHub release
+
+10. **Pull Request**: Create a pull request from the release branch (`release/v{VERSION}`) to the default branch (`3.0.62`).
+
+11. **Merge**: After CI completes successfully, merge the PR to complete the release.
 
 ### Usage
 
-To create a release, simply run:
+To create a release using the PR-based workflow:
 
 ```bash
 make release
@@ -108,10 +100,16 @@ make release
 
 The process will guide you through each step with clear prompts. You can cancel at any point if needed.
 
+**Note**: The command automatically updates the default branch (`3.0.62`) before creating the release branch, so you can run it from any branch. The release branch will always be created from the latest version of the default branch.
+
 ### Example Release Session
 
 ```bash
 $ make release
+Updating default branch (3.0.62) before creating release branch...
+Fetching latest changes from origin...
+Checking out default branch 3.0.62...
+Default branch updated successfully.
 Checking if tag v3.0.62006 already exists...
 Tag v3.0.62006 already exists!
 Current version from VERSION file: 3.0.62006
@@ -127,30 +125,69 @@ VERSION file updated.
 Release Summary:
   Tag: v3.0.62007
   Version: 3.0.62007
+  Release Branch: release/v3.0.62007
+  Target Branch: 3.0.62
 =========================================
 
-Do you want to create tag v3.0.62007? (yes/no): yes
+Do you want to create release branch and tag v3.0.62007? (yes/no): yes
 
-Creating tag v3.0.62007...
+Creating release branch release/v3.0.62007 from updated default branch (3.0.62)...
+Release branch created from updated 3.0.62.
+
+Committing VERSION file change...
 VERSION file change committed.
+
+Creating annotated tag v3.0.62007...
 Tag v3.0.62007 created successfully.
 
-Do you want to deploy this as a GitHub release? (yes/no): yes
+Pushing branch and tag to origin...
+Branch and tag pushed successfully.
 
-Running goreleaser to create GitHub release...
-[... goreleaser output ...]
+=========================================
+Release PR Created Successfully!
+=========================================
 
-Do you want to push tags and commits to GitHub? (yes/no): yes
+Next steps:
+1. GitHub Actions will automatically build the release when the tag is pushed.
+2. Create a pull request:
+   - Source: release/v3.0.62007
+   - Target: 3.0.62
+   - URL: https://github.com/zph/terraform-provider-mysql/compare/3.0.62...release/v3.0.62007
+3. Wait for CI to complete the release build.
+4. Review and merge the PR into 3.0.62 to complete the release.
 
-Pushing to GitHub...
-Release complete! Tag v3.0.62007 has been pushed to GitHub.
+To switch back to your previous branch, run:
+  git checkout your-feature-branch
 ```
+
+### Local Testing Workflow (`make release-local`)
+
+For local testing and debugging, you can use `make release-local` which runs goreleaser locally:
+
+```bash
+make release-local
+```
+
+This command:
+- Runs the same version detection and tag management logic as `make release`
+- Creates tags and commits locally
+- Runs `goreleaser` locally to build and create a GitHub release
+- Requires GPG key setup (set `GPG_FINGERPRINT` environment variable)
+- Requires `goreleaser` installed locally
+
+**Use `make release-local` only for:**
+- Testing release builds locally
+- Debugging goreleaser configuration
+- Creating releases without CI/CD (not recommended for production)
+
+**For production releases, always use `make release` (PR-based workflow).**
 
 ### Troubleshooting
 
-- **GPG signing fails**: Ensure `GPG_FINGERPRINT` is set correctly and your GPG key is available in your keyring
 - **GitHub push fails**: Check your git credentials or SSH keys are configured correctly
-- **goreleaser fails**: Ensure you have the latest version of goreleaser installed and check the `.goreleaser.yml` configuration
+- **Branch already exists**: If the release branch already exists, delete it first or use a different version
+- **CI/CD build fails**: Check GitHub Actions logs for build errors. The release will be created automatically when the tag is pushed successfully
+- **PR merge conflicts**: Resolve conflicts in the PR before merging. The tag and release are already created, so merging just updates the default branch
 
 ## Original Readme
 Below is from petoju/terraform-provider-mysql:

--- a/scripts/make-release.go
+++ b/scripts/make-release.go
@@ -16,7 +16,7 @@ import (
 )
 
 const (
-	defaultBranch = "3.0.62"
+	defaultBranch = "r3.0.62"
 	versionFile   = "VERSION"
 )
 

--- a/scripts/make-release.go
+++ b/scripts/make-release.go
@@ -1,0 +1,467 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/fatih/color"
+	"github.com/hashicorp/go-version"
+)
+
+const (
+	defaultBranch = "3.0.62"
+	versionFile   = "VERSION"
+)
+
+var (
+	green  = color.New(color.FgGreen, color.Bold)
+	yellow = color.New(color.FgYellow, color.Bold)
+	red    = color.New(color.FgRed, color.Bold)
+	cyan   = color.New(color.FgCyan, color.Bold)
+	blue   = color.New(color.FgBlue, color.Bold)
+)
+
+func main() {
+	if err := run(); err != nil {
+		red.Printf("\n❌ Error: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+var originalBranch string
+
+func run() error {
+	// Get the repository root directory
+	repoRoot, err := findRepoRoot()
+	if err != nil {
+		return fmt.Errorf("failed to find repository root: %w", err)
+	}
+
+	if err := os.Chdir(repoRoot); err != nil {
+		return fmt.Errorf("failed to change to repository root: %w", err)
+	}
+
+	// Save original branch
+	originalBranch, err = getCurrentBranch()
+	if err != nil {
+		return fmt.Errorf("failed to get current branch: %w", err)
+	}
+
+	cyan.Println("🚀 Starting release process...")
+	fmt.Println()
+
+	// Step 1: Update default branch
+	if err := updateDefaultBranch(defaultBranch); err != nil {
+		return fmt.Errorf("failed to update default branch: %w", err)
+	}
+
+	// Step 2: Read current version
+	currentVersion, err := readVersionFile()
+	if err != nil {
+		return fmt.Errorf("failed to read VERSION file: %w", err)
+	}
+
+	// Step 3: Determine tag and version
+	tag, versionStr, err := determineTagAndVersion(currentVersion)
+	if err != nil {
+		return fmt.Errorf("failed to determine tag: %w", err)
+	}
+
+	// Step 4: Update VERSION file if needed
+	originalVersion := currentVersion
+	if versionStr != originalVersion {
+		if err := updateVersionFile(versionStr); err != nil {
+			return fmt.Errorf("failed to update VERSION file: %w", err)
+		}
+		green.Printf("✓ Updated VERSION file from %s to %s\n", originalVersion, versionStr)
+	}
+
+	// Step 5: Show summary and confirm
+	releaseBranch := fmt.Sprintf("release/%s", tag)
+	if err := showSummaryAndConfirm(tag, versionStr, releaseBranch, defaultBranch); err != nil {
+		return err
+	}
+
+	// Step 6: Create release branch
+	if err := createReleaseBranch(releaseBranch); err != nil {
+		return fmt.Errorf("failed to create release branch: %w", err)
+	}
+
+	// Step 7: Commit VERSION file if changed
+	if versionStr != originalVersion {
+		if err := commitVersionFile(versionStr); err != nil {
+			return fmt.Errorf("failed to commit VERSION file: %w", err)
+		}
+	}
+
+	// Step 8: Create tag
+	if err := createTag(tag); err != nil {
+		return fmt.Errorf("failed to create tag: %w", err)
+	}
+
+	// Step 9: Push branch and tag
+	if err := pushBranchAndTag(releaseBranch, tag); err != nil {
+		return fmt.Errorf("failed to push: %w", err)
+	}
+
+	// Step 10: Show success message
+	showSuccessMessage(releaseBranch, defaultBranch, tag)
+
+	return nil
+}
+
+func findRepoRoot() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+
+	for {
+		if _, err := os.Stat(filepath.Join(dir, ".git")); err == nil {
+			return dir, nil
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", fmt.Errorf("not in a git repository")
+		}
+		dir = parent
+	}
+}
+
+func updateDefaultBranch(branch string) error {
+	cyan.Printf("📥 Updating default branch (%s) before creating release branch...\n", branch)
+
+	// Fetch latest changes
+	blue.Println("  Fetching latest changes from origin...")
+	if err := runGitCommand("fetch", "origin"); err != nil {
+		return fmt.Errorf("git fetch failed: %w", err)
+	}
+
+	// Check if branch exists on origin
+	if err := runGitCommandSilent("rev-parse", "--verify", fmt.Sprintf("origin/%s", branch)); err != nil {
+		return fmt.Errorf("default branch %s does not exist on origin", branch)
+	}
+
+	// Checkout or create local branch
+	blue.Printf("  Checking out default branch %s...\n", branch)
+	if err := runGitCommandSilent("rev-parse", "--verify", branch); err != nil {
+		// Branch doesn't exist locally, create it
+		if err := runGitCommand("checkout", "-b", branch, fmt.Sprintf("origin/%s", branch)); err != nil {
+			return fmt.Errorf("failed to create local branch: %w", err)
+		}
+	} else {
+		// Branch exists, checkout it
+		if err := runGitCommand("checkout", branch); err != nil {
+			return fmt.Errorf("failed to checkout branch: %w", err)
+		}
+	}
+
+	// Pull latest changes
+	if err := runGitCommand("pull", "origin", branch); err != nil {
+		return fmt.Errorf("git pull failed: %w", err)
+	}
+
+	green.Printf("✓ Default branch updated successfully.\n\n")
+	return nil
+}
+
+func readVersionFile() (string, error) {
+	data, err := os.ReadFile(versionFile)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(data)), nil
+}
+
+func determineTagAndVersion(currentVersion string) (string, string, error) {
+	tag := fmt.Sprintf("v%s", currentVersion)
+	versionStr := currentVersion
+
+	cyan.Printf("🔍 Checking if tag %s already exists...\n", tag)
+
+	// Check if tag exists
+	if err := runGitCommandSilent("rev-parse", tag); err == nil {
+		yellow.Printf("⚠ Tag %s already exists!\n", tag)
+		cyan.Printf("  Current version from VERSION file: %s\n", currentVersion)
+
+		// Find most recent tag
+		lastTag, err := getMostRecentTag()
+		if err != nil {
+			return "", "", fmt.Errorf("failed to get most recent tag: %w", err)
+		}
+
+		if lastTag != "" {
+			lastVersion := strings.TrimPrefix(lastTag, "v")
+			cyan.Printf("  Most recent tag: %s (version: %s)\n", lastTag, lastVersion)
+
+			// Suggest next version
+			nextTag, nextVersion, err := suggestNextVersion(lastVersion)
+			if err != nil {
+				return "", "", fmt.Errorf("failed to suggest next version: %w", err)
+			}
+
+			fmt.Println()
+			yellow.Printf("💡 Suggested next tag: %s\n", nextTag)
+			fmt.Print("  Enter next tag (or press Enter to use suggested): ")
+
+			reader := bufio.NewReader(os.Stdin)
+			userInput, _ := reader.ReadString('\n')
+			userInput = strings.TrimSpace(userInput)
+
+			if userInput == "" {
+				tag = nextTag
+				versionStr = nextVersion
+			} else {
+				if !strings.HasPrefix(userInput, "v") {
+					tag = fmt.Sprintf("v%s", userInput)
+				} else {
+					tag = userInput
+				}
+				versionStr = strings.TrimPrefix(tag, "v")
+			}
+		} else {
+			fmt.Println()
+			fmt.Print("  Could not determine next tag. Please enter manually: ")
+			reader := bufio.NewReader(os.Stdin)
+			userInput, _ := reader.ReadString('\n')
+			userInput = strings.TrimSpace(userInput)
+
+			if !strings.HasPrefix(userInput, "v") {
+				tag = fmt.Sprintf("v%s", userInput)
+			} else {
+				tag = userInput
+			}
+			versionStr = strings.TrimPrefix(tag, "v")
+		}
+	} else {
+		green.Printf("✓ Tag %s does not exist. Using version from VERSION file: %s\n", tag, currentVersion)
+		versionStr = currentVersion
+	}
+
+	fmt.Println()
+	return tag, versionStr, nil
+}
+
+func getMostRecentTag() (string, error) {
+	output, err := runGitCommandOutput("tag", "--list", "v*")
+	if err != nil {
+		return "", err
+	}
+
+	tags := strings.Fields(output)
+	if len(tags) == 0 {
+		return "", nil
+	}
+
+	// Filter tags matching version pattern vX.Y.Z
+	versionRegex := regexp.MustCompile(`^v\d+\.\d+\.\d+`)
+	var versionTags []string
+	for _, tag := range tags {
+		if versionRegex.MatchString(tag) {
+			versionTags = append(versionTags, tag)
+		}
+	}
+
+	if len(versionTags) == 0 {
+		return "", nil
+	}
+
+	// Sort tags by version
+	sort.Slice(versionTags, func(i, j int) bool {
+		v1, err1 := version.NewVersion(strings.TrimPrefix(versionTags[i], "v"))
+		v2, err2 := version.NewVersion(strings.TrimPrefix(versionTags[j], "v"))
+		if err1 != nil || err2 != nil {
+			return versionTags[i] < versionTags[j]
+		}
+		return v1.LessThan(v2)
+	})
+
+	return versionTags[len(versionTags)-1], nil
+}
+
+func suggestNextVersion(lastVersion string) (string, string, error) {
+	parts := strings.Split(lastVersion, ".")
+	if len(parts) < 3 {
+		return "", "", fmt.Errorf("invalid version format: %s", lastVersion)
+	}
+
+	buildNum, err := strconv.Atoi(parts[len(parts)-1])
+	if err != nil {
+		return "", "", fmt.Errorf("invalid build number: %w", err)
+	}
+
+	majorMinor := strings.Join(parts[:len(parts)-1], ".")
+	nextBuild := buildNum + 1
+	nextVersion := fmt.Sprintf("%s.%d", majorMinor, nextBuild)
+	nextTag := fmt.Sprintf("v%s", nextVersion)
+
+	return nextTag, nextVersion, nil
+}
+
+func updateVersionFile(version string) error {
+	return os.WriteFile(versionFile, []byte(version+"\n"), 0644)
+}
+
+func showSummaryAndConfirm(tag, versionStr, releaseBranch, defaultBranch string) error {
+	fmt.Println()
+	cyan.Println("════════════════════════════════════════")
+	blue.Println("  Release Summary:")
+	fmt.Printf("    Tag: %s\n", green.Sprint(tag))
+	fmt.Printf("    Version: %s\n", green.Sprint(versionStr))
+	fmt.Printf("    Release Branch: %s\n", green.Sprint(releaseBranch))
+	fmt.Printf("    Target Branch: %s\n", green.Sprint(defaultBranch))
+	cyan.Println("════════════════════════════════════════")
+	fmt.Println()
+
+	fmt.Printf("❓ Do you want to create release branch and tag %s? (yes/no): ", tag)
+	reader := bufio.NewReader(os.Stdin)
+	response, _ := reader.ReadString('\n')
+	response = strings.TrimSpace(strings.ToLower(response))
+
+	if response != "yes" {
+		yellow.Println("Release cancelled.")
+		os.Exit(0)
+	}
+
+	return nil
+}
+
+func createReleaseBranch(branch string) error {
+	fmt.Println()
+	cyan.Printf("🌿 Creating release branch %s from updated default branch...\n", branch)
+	if err := runGitCommand("checkout", "-b", branch); err != nil {
+		return fmt.Errorf("failed to create release branch: %w", err)
+	}
+	green.Printf("✓ Release branch created.\n")
+	return nil
+}
+
+func commitVersionFile(version string) error {
+	fmt.Println()
+	cyan.Println("📝 Committing VERSION file change...")
+	if err := runGitCommand("add", versionFile); err != nil {
+		return fmt.Errorf("git add failed: %w", err)
+	}
+	if err := runGitCommand("commit", "-m", fmt.Sprintf("Update VERSION to %s", version)); err != nil {
+		return fmt.Errorf("git commit failed: %w", err)
+	}
+	green.Printf("✓ VERSION file change committed.\n")
+	return nil
+}
+
+func createTag(tag string) error {
+	fmt.Println()
+	cyan.Printf("🏷️  Creating annotated tag %s...\n", tag)
+	if err := runGitCommand("tag", "-a", tag, "-m", tag); err != nil {
+		return fmt.Errorf("failed to create tag: %w", err)
+	}
+	green.Printf("✓ Tag %s created successfully.\n", tag)
+	return nil
+}
+
+func pushBranchAndTag(branch, tag string) error {
+	fmt.Println()
+	cyan.Println("📤 Pushing branch and tag to origin...")
+	if err := runGitCommand("push", "origin", branch); err != nil {
+		return fmt.Errorf("failed to push branch: %w", err)
+	}
+	if err := runGitCommand("push", "origin", tag); err != nil {
+		return fmt.Errorf("failed to push tag: %w", err)
+	}
+	green.Println("✓ Branch and tag pushed successfully.")
+	return nil
+}
+
+func showSuccessMessage(releaseBranch, defaultBranch, tag string) {
+	fmt.Println()
+	green.Println("════════════════════════════════════════")
+	green.Println("  Release PR Created Successfully!")
+	green.Println("════════════════════════════════════════")
+	fmt.Println()
+
+	cyan.Println("📋 Next steps:")
+	fmt.Println("  1. GitHub Actions will automatically build the release when the tag is pushed.")
+	fmt.Println("  2. Create a pull request:")
+
+	// Get repository URL
+	repoURL, err := getRepositoryURL()
+	if err == nil {
+		fmt.Printf("     - Source: %s\n", releaseBranch)
+		fmt.Printf("     - Target: %s\n", defaultBranch)
+		fmt.Printf("     - URL: https://github.com/%s/compare/%s...%s\n", repoURL, defaultBranch, releaseBranch)
+	} else {
+		fmt.Printf("     - Source: %s\n", releaseBranch)
+		fmt.Printf("     - Target: %s\n", defaultBranch)
+	}
+
+	fmt.Println("  3. Wait for CI to complete the release build.")
+	fmt.Printf("  4. Review and merge the PR into %s to complete the release.\n", defaultBranch)
+	fmt.Println()
+
+	// Suggest switching back to original branch
+	if originalBranch != "" && originalBranch != releaseBranch {
+		yellow.Printf("💡 To switch back to your previous branch, run:\n")
+		fmt.Printf("     git checkout %s\n", originalBranch)
+	}
+}
+
+func getRepositoryURL() (string, error) {
+	output, err := runGitCommandOutput("config", "--get", "remote.origin.url")
+	if err != nil {
+		return "", err
+	}
+
+	url := strings.TrimSpace(output)
+	// Handle both SSH and HTTPS URLs
+	url = strings.TrimSuffix(url, ".git")
+	if strings.Contains(url, "github.com:") {
+		// SSH format: git@github.com:user/repo
+		parts := strings.Split(url, ":")
+		if len(parts) > 1 {
+			return parts[len(parts)-1], nil
+		}
+	} else if strings.Contains(url, "github.com/") {
+		// HTTPS format: https://github.com/user/repo
+		parts := strings.Split(url, "github.com/")
+		if len(parts) > 1 {
+			return parts[len(parts)-1], nil
+		}
+	}
+
+	return "", fmt.Errorf("could not parse repository URL")
+}
+
+func getCurrentBranch() (string, error) {
+	output, err := runGitCommandOutput("rev-parse", "--abbrev-ref", "HEAD")
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(output), nil
+}
+
+func runGitCommand(args ...string) error {
+	cmd := exec.Command("git", args...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+func runGitCommandSilent(args ...string) error {
+	cmd := exec.Command("git", args...)
+	cmd.Stdout = nil
+	cmd.Stderr = nil
+	return cmd.Run()
+}
+
+func runGitCommandOutput(args ...string) (string, error) {
+	cmd := exec.Command("git", args...)
+	output, err := cmd.Output()
+	return strings.TrimSpace(string(output)), err
+}

--- a/scripts/make-release.go
+++ b/scripts/make-release.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"sort"
 	"strconv"
 	"strings"
@@ -382,21 +383,25 @@ func pushBranchAndTag(branch, tag string) error {
 func showSuccessMessage(releaseBranch, defaultBranch, tag string) {
 	fmt.Println()
 	green.Println("════════════════════════════════════════")
-	green.Println("  Release PR Created Successfully!")
+	green.Println("  Release Branch and Tag Created Successfully!")
 	green.Println("════════════════════════════════════════")
 	fmt.Println()
 
-	cyan.Println("📋 Next steps:")
-	fmt.Println("  1. GitHub Actions will automatically build the release when the tag is pushed.")
-	fmt.Println("  2. Create a pull request:")
-
 	// Get repository URL
 	repoURL, err := getRepositoryURL()
+	prURL := ""
 	if err == nil {
+		prURL = fmt.Sprintf("https://github.com/%s/compare/%s...%s", repoURL, defaultBranch, releaseBranch)
+		cyan.Println("📋 Next steps:")
+		fmt.Println("  1. GitHub Actions will automatically build the release when the tag is pushed.")
+		fmt.Println("  2. Create a pull request:")
 		fmt.Printf("     - Source: %s\n", releaseBranch)
 		fmt.Printf("     - Target: %s\n", defaultBranch)
-		fmt.Printf("     - URL: https://github.com/%s/compare/%s...%s\n", repoURL, defaultBranch, releaseBranch)
+		fmt.Printf("     - URL: %s\n", prURL)
 	} else {
+		cyan.Println("📋 Next steps:")
+		fmt.Println("  1. GitHub Actions will automatically build the release when the tag is pushed.")
+		fmt.Println("  2. Create a pull request:")
 		fmt.Printf("     - Source: %s\n", releaseBranch)
 		fmt.Printf("     - Target: %s\n", defaultBranch)
 	}
@@ -405,11 +410,37 @@ func showSuccessMessage(releaseBranch, defaultBranch, tag string) {
 	fmt.Printf("  4. Review and merge the PR into %s to complete the release.\n", defaultBranch)
 	fmt.Println()
 
+	// Open browser to PR creation page
+	if prURL != "" {
+		cyan.Println("🌐 Opening GitHub PR creation page...")
+		if err := openBrowser(prURL); err != nil {
+			yellow.Printf("⚠ Could not open browser automatically. Please visit: %s\n", prURL)
+		} else {
+			green.Println("✓ Browser opened.")
+		}
+		fmt.Println()
+	}
+
 	// Suggest switching back to original branch
 	if originalBranch != "" && originalBranch != releaseBranch {
 		yellow.Printf("💡 To switch back to your previous branch, run:\n")
 		fmt.Printf("     git checkout %s\n", originalBranch)
 	}
+}
+
+func openBrowser(url string) error {
+	var cmd *exec.Cmd
+	switch runtime.GOOS {
+	case "windows":
+		cmd = exec.Command("cmd", "/c", "start", url)
+	case "darwin":
+		cmd = exec.Command("open", url)
+	case "linux":
+		cmd = exec.Command("xdg-open", url)
+	default:
+		return fmt.Errorf("unsupported platform")
+	}
+	return cmd.Run()
 }
 
 func getRepositoryURL() (string, error) {


### PR DESCRIPTION
- Convert release target from shell script to Go script (scripts/make-release.go)
- Add colored terminal output with emojis for better UX
- Improve error handling and validation
- Use proper version parsing library for tag management
- Update README to reflect PR-based workflow as default
- Simplify Makefile release target to call Go script
- Maintain all existing functionality including default branch updates