### PR TITLE
Make make lint optional and non-failing in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,8 +24,25 @@ jobs:
     steps:
       - name: Checkout Git repo
         uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version-file: go.mod
       - name: Running ${{ matrix.command }}
         run: ${{ matrix.command }}
+
+  lint-optional:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout Git repo
+        uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version-file: go.mod
+      - name: Running make lint
+        continue-on-error: true
+        run: make lint
 
   prepare-dependencies:
     name: Prepare Dependencies

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,15 +1,131 @@
 # GolangCI-Lint configuration
-# Suppress warnings from testcontainers dependencies
+# Focused on correctness checks, not style
+# Run with: golangci-lint run
+
+version: "2"
+
+run:
+  # Timeout for analysis
+  timeout: 5m
+  # Include test files in analysis
+  tests: true
+  # Skip vendor and scripts directories
+  skip-dirs:
+    - vendor
+    - scripts
+  # Skip generated files
+  skip-files:
+    - ".*\\.pb\\.go$"
+    - ".*\\.gen\\.go$"
+
+# Enable only correctness-focused linters
+linters:
+  # Disable all linters first
+  disable-all: true
+  # Enable correctness-focused linters
+  enable:
+    # Core correctness checks
+    - govet          # Reports suspicious constructs
+    - errcheck       # Checks for unchecked errors
+    - staticcheck    # Advanced static analysis (includes type checking and gosimple checks)
+    - ineffassign    # Detects ineffectual assignments
+    - unused         # Finds unused code (replaces deadcode, varcheck, structcheck)
+    - gosec          # Security-focused linter
+    - nilerr         # Finds nil errors that should be checked
+    - unconvert      # Detects unnecessary conversions
+    - unparam        # Finds unused function parameters
+    - gocritic       # Advanced linter (correctness-focused checks, includes exportloopref)
+    - bodyclose      # Checks whether HTTP response body is closed
+    - noctx          # Detects http.Request without context
+    - rowserrcheck   # Checks for errors from database row operations
+    - sqlclosecheck  # Checks that sql.DB, sql.Rows, sql.Stmt, sql.Tx are closed
 
 linters-settings:
-  gci:
-    # Suppress warnings from third-party packages
-    skip-generated: true
+  # govet settings
+  govet:
+    check-shadowing: true
+    enable-all: true
+  
+  # errcheck settings
+  errcheck:
+    check-type-assertions: true
+    check-blank: true
+    ignore: |
+      fmt:.*
+      io:Close|Write
+      bytes:.*
+      github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema:Set
+      database/sql:Rows.Close
+      database/sql:Row.Scan
+  
+  # staticcheck settings
+  staticcheck:
+    checks: ["all"]
+  
+  # gosec settings
+  gosec:
+    severity: medium
+    confidence: medium
+    # Exclude some false positives common in Terraform providers
+    excludes:
+      - G101  # Look for hard coded credentials
+      - G104  # Errors unhandled (we use errcheck for this)
+      - G307  # Deferring a method which returns an error
+  
+  # gocritic settings - enable correctness-focused checks
+  gocritic:
+    enabled-tags:
+      - diagnostic
+      - experimental
+      - opinionated
+    disabled-checks:
+      # Style-focused checks to disable
+      - dupImport
+      - importShadow
+      - ifElseChain
+      - octalLiteral
+      - whyNoLint
+      - wrapperFunc
+      # Keep correctness-focused checks enabled
+  
+  # unused settings
+  unused:
+    check-exported: false  # Don't require exported functions to be used
+  
+  # unparam settings
+  unparam:
+    check-exported: false  # Don't require exported functions to use all params
 
 issues:
+  # Maximum issues count per one linter
+  max-issues-per-linter: 0
+  # Maximum count of issues with the same text
+  max-same-issues: 0
+  
   exclude-rules:
-    # Suppress warnings from go-m1cpu (testcontainers dependency)
+    # Exclude scripts directory (contains separate programs)
+    - path: scripts/.*
+    
+    # Suppress warnings from testcontainers dependencies
     - path: _test\.go
       linters:
         - gocritic
       text: ".*go-m1cpu.*"
+    
+    # Allow unused parameters in test helpers
+    - path: _test\.go
+      linters:
+        - unparam
+      text: ".*is unused"
+    
+    # Suppress some false positives in test files
+    - path: _test\.go
+      linters:
+        - errcheck
+      text: "Error return value of .* is not checked"
+    
+    # Allow defer in test cleanup functions
+    - path: _test\.go
+      linters:
+        - gosec
+      text: ".*defer.*"

--- a/Makefile
+++ b/Makefile
@@ -224,6 +224,20 @@ errcheck: ## Run errcheck
 		exit 1; \
 	fi
 
+lint: ## Run golangci-lint (correctness-focused linters)
+	@echo "==> Running golangci-lint..."
+	@GOPATH_BIN=$$(go env GOPATH)/bin; \
+	GOLANGCI_LINT=$$GOPATH_BIN/golangci-lint; \
+	if [ ! -f $$GOLANGCI_LINT ]; then \
+		echo "==> Installing golangci-lint..."; \
+		curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $$GOPATH_BIN latest; \
+	fi; \
+	$$GOLANGCI_LINT run ./mysql/... ; if [ $$? -eq 1 ]; then \
+		echo ""; \
+		echo "Linter found issues. Please review and fix them before submitting code."; \
+		exit 1; \
+	fi
+
 vendor-status: ## Show vendor status
 	@govendor status
 
@@ -373,4 +387,4 @@ release-local: ## Create a release locally (for testing - use 'make release' for
 release: ## Create a release PR branch (tag, push branch and tag, then create PR to merge to default branch)
 	@go run scripts/make-release.go
 
-.PHONY: help build test testacc vet fmt fmtcheck errcheck vendor-status test-compile website website-test tag format-tag release release-local
+.PHONY: help build test testacc vet fmt fmtcheck errcheck lint vendor-status test-compile website website-test tag format-tag release release-local


### PR DESCRIPTION
- Split make lint into separate lint-optional job
- Only make lint uses continue-on-error: true
- make vet and make fmtcheck remain as required checks