### PR TITLE
Centralize test matrix and enforce version policy

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -98,9 +98,27 @@ jobs:
           retention-days: 1
           compression-level: 6
 
-  tests:
+  unit-tests:
+    name: Unit Tests
     runs-on: ubuntu-22.04
-    needs: [prepare-dependencies]
+    steps:
+      - name: Checkout Git repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version-file: go.mod
+
+      - name: Run unit tests via Makefile
+        run: make test-unit
+
+  tests:
+    name: Acceptance Matrix
+    runs-on: ubuntu-22.04
+    needs: [prepare-dependencies, unit-tests]
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.prepare-dependencies.outputs.test_matrix) }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -121,7 +121,7 @@ jobs:
     permissions:
       contents: read
       issues: write
-      pull-requests: read
+      pull-requests: write
     steps:
       - name: Checkout Git repo
         uses: actions/checkout@v4
@@ -201,11 +201,11 @@ jobs:
           script: |
             const exitCode = Number(process.env.MATRIX_POLICY_EXIT_CODE || '1') || 1;
             const commentOutcome = process.env.MATRIX_POLICY_COMMENT_OUTCOME || 'skipped';
-            const destination = context.eventName === 'pull_request'
+            const destination = context.eventName === 'pull_request' && commentOutcome === 'success'
               ? 'See the sticky Matrix Version Policy PR comment and this job summary for the full table.'
               : 'See this job summary for the full table.';
             const commentNote = context.eventName === 'pull_request' && commentOutcome !== 'success'
-              ? ` PR comment step outcome: ${commentOutcome}.`
+              ? ` PR comment was not written; comment step outcome: ${commentOutcome}.`
               : '';
             core.setFailed(`Matrix version policy failed because the version table contains red rows. ${destination}${commentNote}`);
             process.exitCode = exitCode;

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,11 +7,6 @@ on:
   pull_request:
     branches: [ "*" ]
 
-# TiDB versions used in tests - single source of truth
-# Latest version of each minor series: 6.1.x, 6.5.x, 7.1.x, 7.5.x, 8.1.x, 8.5.x
-env:
-  TIDB_VERSIONS: "6.1.7 6.5.12 7.1.6 7.5.7 8.1.2 8.5.5"
-
 jobs:
   lint:
     runs-on: ubuntu-22.04
@@ -30,41 +25,23 @@ jobs:
   prepare-dependencies:
     name: Prepare Dependencies
     runs-on: ubuntu-22.04
+    outputs:
+      test_matrix: ${{ steps.test-matrix.outputs.test_matrix }}
     steps:
       - name: Checkout Git repo
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
 
-      - name: Validate TiDB versions sync
-        run: |
-          # Extract TiDB versions from test matrix and compare with env.TIDB_VERSIONS
-          EXPECTED_VERSIONS="${{ env.TIDB_VERSIONS }}"
-          MATRIX_VERSIONS=$(grep -A 20 "db_type: tidb" .github/workflows/main.yml | grep "db_version:" | sed 's/.*db_version: "\([0-9.]*\)".*/\1/' | tr '\n' ' ' | xargs)
-
-          echo "Expected versions (from env): $EXPECTED_VERSIONS"
-          echo "Matrix versions (from workflow): $MATRIX_VERSIONS"
-
-          # Check if versions match (simple check - both should contain same versions)
-          MISSING=""
-          for version in $EXPECTED_VERSIONS; do
-            if ! echo "$MATRIX_VERSIONS" | grep -q "$version"; then
-              MISSING="$MISSING $version"
-            fi
-          done
-
-          if [ -n "$MISSING" ]; then
-            echo "ERROR: TiDB versions in env.TIDB_VERSIONS not found in test matrix: $MISSING"
-            echo "Please ensure test matrix includes tidb entries for all versions in env.TIDB_VERSIONS"
-            exit 1
-          fi
-
-          echo "✓ TiDB versions are in sync"
-
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
           go-version-file: go.mod
+
+      - name: Generate test matrix
+        id: test-matrix
+        run: |
+          printf 'test_matrix=%s\n' "$(go run scripts/test-matrix.go --github-actions)" >> "$GITHUB_OUTPUT"
 
       - name: Download Terraform
         run: |
@@ -126,51 +103,7 @@ jobs:
     needs: [prepare-dependencies]
     strategy:
       fail-fast: false
-      matrix:
-        include:
-        # MySQL versions
-        - db_type: mysql
-          db_version: "5.7"
-          make_target: "test-mysql-5.7"
-        - db_type: mysql
-          db_version: "8.0"
-          make_target: "test-mysql-8.0"
-        # Percona versions
-        - db_type: percona
-          db_version: "5.7"
-          make_target: "test-percona-5.7"
-        - db_type: percona
-          db_version: "8.0"
-          make_target: "test-percona-8.0"
-        # MariaDB versions
-        - db_type: mariadb
-          db_version: "10.3"
-          make_target: "test-mariadb-10.3"
-        - db_type: mariadb
-          db_version: "10.8"
-          make_target: "test-mariadb-10.8"
-        - db_type: mariadb
-          db_version: "10.10"
-          make_target: "test-mariadb-10.10"
-        # TiDB versions - must match env.TIDB_VERSIONS: 6.1.7 6.5.12 7.1.6 7.5.7 8.1.2 8.5.5
-        - db_type: tidb
-          db_version: "6.1.7"
-          make_target: "test-tidb-6.1.7"
-        - db_type: tidb
-          db_version: "6.5.12"
-          make_target: "test-tidb-6.5.12"
-        - db_type: tidb
-          db_version: "7.1.6"
-          make_target: "test-tidb-7.1.6"
-        - db_type: tidb
-          db_version: "7.5.7"
-          make_target: "test-tidb-7.5.7"
-        - db_type: tidb
-          db_version: "8.1.2"
-          make_target: "test-tidb-8.1.2"
-        - db_type: tidb
-          db_version: "8.5.5"
-          make_target: "test-tidb-8.5.5"
+      matrix: ${{ fromJSON(needs.prepare-dependencies.outputs.test_matrix) }}
     steps:
       - name: Checkout Git repo
         uses: actions/checkout@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -118,6 +118,10 @@ jobs:
   matrix-version-policy:
     name: Matrix Version Policy
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: read
     steps:
       - name: Checkout Git repo
         uses: actions/checkout@v4
@@ -130,7 +134,65 @@ jobs:
           go-version-file: go.mod
 
       - name: Check matrix versions
-        run: make eol-versions-ci
+        id: matrix-policy
+        env:
+          MATRIX_POLICY_SUMMARY_FILE: ${{ runner.temp }}/matrix-version-policy.md
+        run: |
+          set +e
+          rm -f "$MATRIX_POLICY_SUMMARY_FILE"
+          make eol-versions-ci
+          status=$?
+          printf 'exit_code=%s\n' "$status" >> "$GITHUB_OUTPUT"
+          printf 'summary_file=%s\n' "$MATRIX_POLICY_SUMMARY_FILE" >> "$GITHUB_OUTPUT"
+          exit 0
+
+      - name: Update matrix policy PR comment
+        if: always() && github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        continue-on-error: true
+        env:
+          MATRIX_POLICY_SUMMARY_FILE: ${{ steps.matrix-policy.outputs.summary_file }}
+        with:
+          script: |
+            const fs = require('fs');
+            const marker = '<!-- terraform-provider-mysql:matrix-version-policy -->';
+            const summaryFile = process.env.MATRIX_POLICY_SUMMARY_FILE;
+
+            if (!summaryFile || !fs.existsSync(summaryFile)) {
+              core.warning('Matrix policy summary file was not written; skipping PR comment.');
+              return;
+            }
+
+            const summary = fs.readFileSync(summaryFile, 'utf8').trim();
+            const { owner, repo } = context.repo;
+            const issue_number = context.issue.number;
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number,
+              per_page: 100,
+            });
+            const previous = comments.find((comment) =>
+              comment.user.type === 'Bot' && comment.body.includes(marker)
+            );
+
+            if (summary.includes('All matrix versions are current and supported.')) {
+              if (previous) {
+                await github.rest.issues.deleteComment({ owner, repo, comment_id: previous.id });
+              }
+              return;
+            }
+
+            const body = `${marker}\n${summary}\n\n_This comment is updated automatically by the Matrix Version Policy workflow._`;
+            if (previous) {
+              await github.rest.issues.updateComment({ owner, repo, comment_id: previous.id, body });
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number, body });
+            }
+
+      - name: Fail matrix version policy
+        if: steps.matrix-policy.outputs.exit_code != '0'
+        run: exit "${{ steps.matrix-policy.outputs.exit_code }}"
 
   tests:
     name: Acceptance Matrix

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -147,6 +147,7 @@ jobs:
           exit 0
 
       - name: Update matrix policy PR comment
+        id: matrix-policy-comment
         if: always() && github.event_name == 'pull_request'
         uses: actions/github-script@v7
         continue-on-error: true
@@ -192,7 +193,22 @@ jobs:
 
       - name: Fail matrix version policy
         if: steps.matrix-policy.outputs.exit_code != '0'
-        run: exit "${{ steps.matrix-policy.outputs.exit_code }}"
+        uses: actions/github-script@v7
+        env:
+          MATRIX_POLICY_EXIT_CODE: ${{ steps.matrix-policy.outputs.exit_code }}
+          MATRIX_POLICY_COMMENT_OUTCOME: ${{ steps.matrix-policy-comment.outcome }}
+        with:
+          script: |
+            const exitCode = Number(process.env.MATRIX_POLICY_EXIT_CODE || '1') || 1;
+            const commentOutcome = process.env.MATRIX_POLICY_COMMENT_OUTCOME || 'skipped';
+            const destination = context.eventName === 'pull_request'
+              ? 'See the sticky Matrix Version Policy PR comment and this job summary for the full table.'
+              : 'See this job summary for the full table.';
+            const commentNote = context.eventName === 'pull_request' && commentOutcome !== 'success'
+              ? ` PR comment step outcome: ${commentOutcome}.`
+              : '';
+            core.setFailed(`Matrix version policy failed because the version table contains red rows. ${destination}${commentNote}`);
+            process.exitCode = exitCode;
 
   tests:
     name: Acceptance Matrix

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -115,6 +115,23 @@ jobs:
       - name: Run unit tests via Makefile
         run: make test-unit
 
+  matrix-version-policy:
+    name: Matrix Version Policy
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout Git repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version-file: go.mod
+
+      - name: Check matrix versions
+        run: make eol-versions-ci
+
   tests:
     name: Acceptance Matrix
     runs-on: ubuntu-22.04
@@ -179,7 +196,7 @@ jobs:
 
   release:
     name: 'Terraform Provider Release'
-    needs: [tests]
+    needs: [tests, matrix-version-policy]
     if: startsWith(github.ref, 'refs/tags/v')
     uses: hashicorp/ghaction-terraform-provider-release/.github/workflows/community.yml@v5
     secrets:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ on:
 # TiDB versions used in tests - single source of truth
 # Latest version of each minor series: 6.1.x, 6.5.x, 7.1.x, 7.5.x, 8.1.x, 8.5.x
 env:
-  TIDB_VERSIONS: "6.1.7 6.5.12 7.1.6 7.5.7 8.1.2 8.5.3"
+  TIDB_VERSIONS: "6.1.7 6.5.12 7.1.6 7.5.7 8.1.2 8.5.5"
 
 jobs:
   lint:
@@ -130,9 +130,6 @@ jobs:
         include:
         # MySQL versions
         - db_type: mysql
-          db_version: "5.6"
-          make_target: "test-mysql-5.6"
-        - db_type: mysql
           db_version: "5.7"
           make_target: "test-mysql-5.7"
         - db_type: mysql
@@ -155,7 +152,7 @@ jobs:
         - db_type: mariadb
           db_version: "10.10"
           make_target: "test-mariadb-10.10"
-        # TiDB versions - must match env.TIDB_VERSIONS: 6.1.7 6.5.12 7.1.6 7.5.7 8.1.2 8.5.3
+        # TiDB versions - must match env.TIDB_VERSIONS: 6.1.7 6.5.12 7.1.6 7.5.7 8.1.2 8.5.5
         - db_type: tidb
           db_version: "6.1.7"
           make_target: "test-tidb-6.1.7"
@@ -172,8 +169,8 @@ jobs:
           db_version: "8.1.2"
           make_target: "test-tidb-8.1.2"
         - db_type: tidb
-          db_version: "8.5.3"
-          make_target: "test-tidb-8.5.3"
+          db_version: "8.5.5"
+          make_target: "test-tidb-8.5.5"
     steps:
       - name: Checkout Git repo
         uses: actions/checkout@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -156,8 +156,8 @@ jobs:
           TF_ACC: 1
         run: |
           export PATH="${{ github.workspace }}/bin:$PATH"
-          echo "Running ${{ matrix.db_type }} ${{ matrix.db_version }} tests using Makefile target: ${{ matrix.make_target }}"
-          make ${{ matrix.make_target }}
+          echo "Running ${{ matrix.db_type }} ${{ matrix.db_version }} tests"
+          make testcontainers-db DB="${{ matrix.db_type }}" VERSION="${{ matrix.db_version }}"
 
   release:
     name: 'Terraform Provider Release'

--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,8 @@ help: ## Show this help message
 	@echo '  make test-unit          Run unit tests without testcontainers'
 	@echo '  make test-integration   Run testcontainers integration matrix'
 	@echo '  make testcontainers-db DB=mysql VERSION=8.0'
+	@echo '  make eol-versions      Check matrix patch drift and EOL warnings'
+	@echo '  make eol-versions-ci   Enforce matrix version policy for CI'
 	@echo '  make test VERBOSE=1    Run unit and integration tests, streaming integration output'
 	@echo '  make acceptance        Run integration tests sequentially'
 	@echo '  make testcontainers-matrix  Run test matrix across all database versions'
@@ -115,8 +117,13 @@ testcontainers-db: fmtcheck bin/terraform ## Run tests for a database/version pa
 	fi
 	@$(TESTCONTAINERS_RUNNER) --db "$(DB)" --version "$(VERSION)" $(TESTARGS)
 
-testcontainers-matrix-check: ## Check matrix image patch drift and EOL warnings
+eol-versions: ## Check matrix image patch drift and EOL warnings
 	@go run scripts/update-test-matrix.go
+
+eol-versions-ci: ## Enforce matrix version policy for CI
+	@go run scripts/update-test-matrix.go --github-actions --fail-on-red
+
+testcontainers-matrix-check: eol-versions-ci ## Enforce matrix version policy for CI
 
 testcontainers-matrix-update: ## Update matrix image patch versions in known files
 	@go run scripts/update-test-matrix.go --write
@@ -377,4 +384,4 @@ release-local: ## Create a release locally (for testing - use 'make release' for
 release: ## Create a release PR branch (tag, push branch and tag, then create PR to merge to default branch)
 	@go run scripts/make-release.go
 
-.PHONY: help build test test-unit test-integration test-sequential testcontainers-matrix testcontainers-image testcontainers-db testcontainers-matrix-check testcontainers-matrix-update testacc acceptance vet fmt fmtcheck errcheck vendor-status test-compile website website-test tag format-tag release release-local
+.PHONY: help build test test-unit test-integration test-sequential testcontainers-matrix testcontainers-image testcontainers-db eol-versions eol-versions-ci testcontainers-matrix-check testcontainers-matrix-update testacc acceptance vet fmt fmtcheck errcheck vendor-status test-compile website website-test tag format-tag release release-local

--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,7 @@ NAME=mysql
 VERSION=9.9.9
 TESTCONTAINERS_TIMEOUT?=30m
 TESTCONTAINERS_RUNNER=cd $(CURDIR) && PATH="$(CURDIR)/bin:${PATH}" PARALLEL="$${PARALLEL:-1}" go run scripts/test-runner.go --package "$(TEST)" --timeout "$(TESTCONTAINERS_TIMEOUT)" $(if $(VERBOSE),--verbose,)
+MATRIX_POLICY_ARGS=--github-actions --fail-on-red $(if $(MATRIX_POLICY_SUMMARY_FILE),--summary-file "$(MATRIX_POLICY_SUMMARY_FILE)",)
 ## on linux base os
 TERRAFORM_PLUGINS_DIRECTORY=~/.terraform.d/plugins/${HOSTNAME}/${NAMESPACE}/${NAME}/${VERSION}/${OS_ARCH}
 
@@ -121,7 +122,7 @@ eol-versions: ## Check matrix image patch drift and EOL warnings
 	@go run scripts/update-test-matrix.go
 
 eol-versions-ci: ## Enforce matrix version policy for CI
-	@go run scripts/update-test-matrix.go --github-actions --fail-on-red
+	@go run scripts/update-test-matrix.go $(MATRIX_POLICY_ARGS)
 
 testcontainers-matrix-check: eol-versions-ci ## Enforce matrix version policy for CI
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 TEST?=./mysql/...
-UNIT_TEST?=./internal/...
+UNIT_TEST?=./internal/... ./mysql
 UNIT_TEST_TIMEOUT?=5m
 GOFMT_FILES?=$$(find . -name '*.go' |grep -v vendor)
 WEBSITE_REPO=github.com/hashicorp/terraform-website

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
 TEST?=./mysql/...
+UNIT_TEST?=./internal/...
+UNIT_TEST_TIMEOUT?=5m
 GOFMT_FILES?=$$(find . -name '*.go' |grep -v vendor)
 WEBSITE_REPO=github.com/hashicorp/terraform-website
 PKG_NAME=mysql
@@ -45,9 +47,11 @@ help: ## Show this help message
 	@echo 'Examples:'
 	@echo '  make build              Build the provider'
 	@echo '  make release            Create a release PR branch (PR-based workflow)'
+	@echo '  make test-unit          Run unit tests without testcontainers'
+	@echo '  make test-integration   Run testcontainers integration matrix'
 	@echo '  make testcontainers-db DB=mysql VERSION=8.0'
-	@echo '  make test VERBOSE=1    Run test matrix and stream go test output'
-	@echo '  make acceptance        Run all acceptance tests'
+	@echo '  make test VERBOSE=1    Run unit and integration tests, streaming integration output'
+	@echo '  make acceptance        Run integration tests sequentially'
 	@echo '  make testcontainers-matrix  Run test matrix across all database versions'
 
 default: help
@@ -86,12 +90,16 @@ build-tiup-playground-image: ## Pre-build TiUP Playground Docker image for cachi
 	@docker build -f Dockerfile.tiup-playground -t terraform-provider-mysql-tiup-playground:latest .
 	@echo "✓ TiUP Playground image built successfully: terraform-provider-mysql-tiup-playground:latest"
 
-test: testcontainers-matrix ## Run all acceptance tests
-test-sequential: acceptance
+test: test-unit test-integration ## Run unit tests, then integration tests
+test-unit: fmtcheck ## Run unit tests that do not require testcontainers or external database servers
+	@go test $(UNIT_TEST) $(if $(TESTARGS),-run "$(TESTARGS)",) -timeout=$(UNIT_TEST_TIMEOUT)
 
-# Run testcontainers tests with a matrix of all database versions
+test-integration: testcontainers-matrix ## Run testcontainers integration tests
+test-sequential: acceptance ## Run testcontainers integration tests sequentially
+
+# Run testcontainers integration tests with a matrix of all database versions
 # Usage: make testcontainers-matrix TESTARGS="TestAccUser"
-testcontainers-matrix: fmtcheck bin/terraform ## Run test matrix across all database versions
+testcontainers-matrix: fmtcheck bin/terraform ## Run integration test matrix across all database versions
 	@PARALLEL=$(if $(VERBOSE),1,4); $(TESTCONTAINERS_RUNNER) $(TESTARGS)
 
 # Run testcontainers tests for a specific database image
@@ -121,7 +129,7 @@ bin/terraform: ## Download Terraform binary
 testacc: fmtcheck bin/terraform ## Run acceptance tests (requires MYSQL_ENDPOINT env vars)
 	PATH="$(CURDIR)/bin:${PATH}" TF_ACC=1 go test $(TEST) -v $(TESTARGS) -timeout=90s
 
-acceptance: fmtcheck bin/terraform ## Run all acceptance tests across all database versions
+acceptance: fmtcheck bin/terraform ## Run integration test matrix sequentially
 	@PARALLEL=1; $(TESTCONTAINERS_RUNNER) $(TESTARGS)
 
 # MySQL test targets - use testcontainers
@@ -369,4 +377,4 @@ release-local: ## Create a release locally (for testing - use 'make release' for
 release: ## Create a release PR branch (tag, push branch and tag, then create PR to merge to default branch)
 	@go run scripts/make-release.go
 
-.PHONY: help build test testacc vet fmt fmtcheck errcheck vendor-status test-compile website website-test tag format-tag release release-local
+.PHONY: help build test test-unit test-integration test-sequential testcontainers-matrix testcontainers-image testcontainers-db testcontainers-matrix-check testcontainers-matrix-update testacc acceptance vet fmt fmtcheck errcheck vendor-status test-compile website website-test tag format-tag release release-local

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,8 @@ HOSTNAME=registry.terraform.io
 NAMESPACE=zph
 NAME=mysql
 VERSION=9.9.9
-TESTCONTAINERS_RUNNER=cd $(CURDIR) && PATH="$(CURDIR)/bin:${PATH}" PARALLEL="$${PARALLEL:-1}" go run scripts/test-runner.go --package "$(TEST)" $(if $(VERBOSE),--verbose,)
+TESTCONTAINERS_TIMEOUT?=30m
+TESTCONTAINERS_RUNNER=cd $(CURDIR) && PATH="$(CURDIR)/bin:${PATH}" PARALLEL="$${PARALLEL:-1}" go run scripts/test-runner.go --package "$(TEST)" --timeout "$(TESTCONTAINERS_TIMEOUT)" $(if $(VERBOSE),--verbose,)
 ## on linux base os
 TERRAFORM_PLUGINS_DIRECTORY=~/.terraform.d/plugins/${HOSTNAME}/${NAMESPACE}/${NAME}/${VERSION}/${OS_ARCH}
 
@@ -44,9 +45,8 @@ help: ## Show this help message
 	@echo 'Examples:'
 	@echo '  make build              Build the provider'
 	@echo '  make release            Create a release PR branch (PR-based workflow)'
-	@echo '  make testversion8.0    Run tests against MySQL 8.0'
-	@echo '  make testtidb8.5.5     Run tests against TiDB 8.5.5'
-	@echo '  make test VERBOSE=1   Run test matrix and stream go test output'
+	@echo '  make testcontainers-db DB=mysql VERSION=8.0'
+	@echo '  make test VERBOSE=1    Run test matrix and stream go test output'
 	@echo '  make acceptance        Run all acceptance tests'
 	@echo '  make testcontainers-matrix  Run test matrix across all database versions'
 
@@ -100,6 +100,13 @@ testcontainers-matrix: fmtcheck bin/terraform ## Run test matrix across all data
 testcontainers-image: fmtcheck bin/terraform ## Run tests for a specific database image (set DOCKER_IMAGE)
 	@$(TESTCONTAINERS_RUNNER) --image "$(DOCKER_IMAGE)" $(TESTARGS)
 
+testcontainers-db: fmtcheck bin/terraform ## Run tests for a database/version pair (set DB and VERSION)
+	@if [ -z "$(DB)" ] || [ -z "$(VERSION)" ]; then \
+		echo "ERROR: set DB and VERSION. Example: make testcontainers-db DB=mysql VERSION=8.0"; \
+		exit 1; \
+	fi
+	@$(TESTCONTAINERS_RUNNER) --db "$(DB)" --version "$(VERSION)" $(TESTARGS)
+
 testcontainers-matrix-check: ## Check matrix image patch drift and EOL warnings
 	@go run scripts/update-test-matrix.go
 
@@ -120,24 +127,24 @@ acceptance: fmtcheck bin/terraform ## Run all acceptance tests across all databa
 # MySQL test targets - use testcontainers
 # Preferred format: test-mysql-VERSION (e.g., test-mysql-8.0)
 test-mysql-%: ## Run tests against MySQL version (e.g., test-mysql-8.0)
-	@$(MAKE) testversion$*
+	@$(MAKE) testcontainers-db DB=mysql VERSION="$*"
 
 testversion%: ## Run tests against MySQL version (e.g., testversion8.0) [backwards compatible]
-	@$(TESTCONTAINERS_RUNNER) --db mysql --version "$*" --timeout 30m $(TESTARGS)
+	@$(MAKE) testcontainers-db DB=mysql VERSION="$*"
 
 testversion: ## Run tests against MySQL version (set MYSQL_VERSION)
-	@$(TESTCONTAINERS_RUNNER) --db mysql --version "$(MYSQL_VERSION)" --timeout 30m $(TESTARGS)
+	@$(MAKE) testcontainers-db DB=mysql VERSION="$(MYSQL_VERSION)"
 
 # Percona test targets - use testcontainers
 # Preferred format: test-percona-VERSION (e.g., test-percona-8.0)
 test-percona-%: ## Run tests against Percona version (e.g., test-percona-8.0)
-	@$(MAKE) testpercona$*
+	@$(MAKE) testcontainers-db DB=percona VERSION="$*"
 
 testpercona%: ## Run tests against Percona version (e.g., testpercona8.0) [backwards compatible]
-	@$(TESTCONTAINERS_RUNNER) --db percona --version "$*" --timeout 30m $(TESTARGS)
+	@$(MAKE) testcontainers-db DB=percona VERSION="$*"
 
 testpercona: ## Run tests against Percona version (set MYSQL_VERSION)
-	@$(TESTCONTAINERS_RUNNER) --db percona --version "$(MYSQL_VERSION)" --timeout 30m $(TESTARGS)
+	@$(MAKE) testcontainers-db DB=percona VERSION="$(MYSQL_VERSION)"
 
 testrdsdb%: ## Run tests against RDS MySQL version (requires MYSQL_ENDPOINT env vars)
 	$(MAKE) MYSQL_VERSION=$* MYSQL_USERNAME=${MYSQL_USERNAME} MYSQL_HOST=$(shell echo ${MYSQL_ENDPOINT} | cut -d: -f1) MYSQL_PASSWORD=${MYSQL_PASSWORD} MYSQL_PORT=$(shell echo ${MYSQL_ENDPOINT} | cut -d: -f2) testrdsdb
@@ -150,24 +157,24 @@ testrdsdb: ## Run tests against Amazon RDS (requires MYSQL_ENDPOINT env vars)
 # TiDB test targets - use testcontainers
 # Preferred format: test-tidb-VERSION (e.g., test-tidb-8.5.5)
 test-tidb-%: ## Run tests against TiDB version (e.g., test-tidb-8.5.5)
-	@$(MAKE) testtidb$*
+	@$(MAKE) testcontainers-db DB=tidb VERSION="$*"
 
 testtidb%: ## Run tests against TiDB version (e.g., testtidb8.5.5) [backwards compatible]
-	@$(TESTCONTAINERS_RUNNER) --db tidb --version "$*" --timeout 30m $(TESTARGS)
+	@$(MAKE) testcontainers-db DB=tidb VERSION="$*"
 
 testtidb: ## Run tests against TiDB version (set MYSQL_VERSION)
-	@$(TESTCONTAINERS_RUNNER) --db tidb --version "$(MYSQL_VERSION)" --timeout 30m $(TESTARGS)
+	@$(MAKE) testcontainers-db DB=tidb VERSION="$(MYSQL_VERSION)"
 
 # MariaDB test targets - use testcontainers
 # Preferred format: test-mariadb-VERSION (e.g., test-mariadb-10.10)
 test-mariadb-%: ## Run tests against MariaDB version (e.g., test-mariadb-10.10)
-	@$(MAKE) testmariadb$*
+	@$(MAKE) testcontainers-db DB=mariadb VERSION="$*"
 
 testmariadb%: ## Run tests against MariaDB version (e.g., testmariadb10.10) [backwards compatible]
-	@$(TESTCONTAINERS_RUNNER) --db mariadb --version "$*" --timeout 30m $(TESTARGS)
+	@$(MAKE) testcontainers-db DB=mariadb VERSION="$*"
 
 testmariadb: ## Run tests against MariaDB version (set MYSQL_VERSION)
-	@$(TESTCONTAINERS_RUNNER) --db mariadb --version "$(MYSQL_VERSION)" --timeout 30m $(TESTARGS)
+	@$(MAKE) testcontainers-db DB=mariadb VERSION="$(MYSQL_VERSION)"
 
 vet: ## Run go vet
 	@echo "go vet ."

--- a/README.md
+++ b/README.md
@@ -25,22 +25,19 @@ released there.
 
 ## Security / Chain of Custody
 
-We sign releases with a GPG key currently using goreleaser locally on the personal
-equipment of @ZPH. As the maintainer of this fork, I, @ZPH, attest that the builds
-represent the exact SHA of the version control with no alterations. The credentials
-are stored in a credential manager with layers of safeguards and no other individuals
-have access.
+Production releases are built, checksummed, signed, and published by GitHub Actions
+from pushed `v*` tags. The release job in `.github/workflows/main.yml` uses
+HashiCorp's Terraform provider release workflow after the required tests and matrix
+version policy checks pass.
 
-The near term goal is to setup github actions to provide this guarantee
-so that even if I were a malicious actor or coerced,
-I could not introduce opaque security issues into binary releases.
-
-In the meantime, I certify by my professional reputation and career as:
-https://www.linkedin.com/in/zph/ that appropriate safeguards are being taken.
+Local machines are only used to prepare the release branch and push the annotated
+tag with `make release`. They do not separately build or publish production release
+artifacts. The release artifacts are reproducible and verifiable from the tag SHA,
+the GitHub Actions workflow run, and the published checksums and signature.
 
 ## Release Process
 
-The release process uses a PR-based workflow through the `make release` command. This creates a release branch, tags the release, and pushes both to GitHub. GitHub Actions then automatically builds and creates the release when the tag is pushed.
+The release process uses a PR-based workflow through the `make release` command. This creates a release branch, tags the release, and pushes both to GitHub. A pushed `v*` tag triggers GitHub Actions, and the release job automatically builds and publishes the release after the required checks pass.
 
 ### Prerequisites
 
@@ -79,7 +76,7 @@ The `make release` command implements a PR-based workflow:
 
 8. **Push to GitHub**: Pushes both the release branch and tag to GitHub.
 
-9. **GitHub Actions**: When the tag is pushed, GitHub Actions automatically:
+9. **GitHub Actions**: When the `v*` tag is pushed and the required checks pass, GitHub Actions automatically:
    - Builds binaries for all supported platforms (Linux, macOS, Windows, FreeBSD)
    - Creates archives (zip files) for each platform/architecture combination
    - Generates SHA256 checksums
@@ -186,7 +183,7 @@ This command:
 
 - **GitHub push fails**: Check your git credentials or SSH keys are configured correctly
 - **Branch already exists**: If the release branch already exists, delete it first or use a different version
-- **CI/CD build fails**: Check GitHub Actions logs for build errors. The release will be created automatically when the tag is pushed successfully
+- **CI/CD build fails**: Check GitHub Actions logs for build errors. The release is created automatically by the tag workflow after the required jobs pass
 - **PR merge conflicts**: Resolve conflicts in the PR before merging. The tag and release are already created, so merging just updates the default branch
 
 ## Original Readme
@@ -226,8 +223,12 @@ provider "mysql" {
 Building The Provider
 ---------------------
 
-If you want to reproduce a build (to verify my build confirms to sources),
-download the provider of any version first and find the correct go version:
+For this fork, production release artifacts are built by GitHub Actions from the
+published tag. To verify a release, compare the tag SHA, the GitHub Actions release
+workflow run, and the published checksums and signature.
+
+For local debugging or exploratory reproduction, download the provider of any
+version first and find the correct go version:
 ```
 egrep -a -o 'go1[0-9\.]+' path_to_the_provider_binary
 ```

--- a/README.md
+++ b/README.md
@@ -290,11 +290,15 @@ make testversion8.0
 
 ### CI Testing Strategy
 
-Our CI workflow tests against multiple TiDB versions (latest of each minor series) to ensure compatibility across different releases. To optimize cache performance and avoid timeouts, we cache each TiDB version separately rather than caching all versions together. This approach:
+Our CI workflow tests the database matrix defined in `internal/testmatrix/matrix.go`
+across MySQL, Percona Server, MariaDB, and TiDB. The matrix policy is:
 
-- Prevents cache upload timeouts (each cache is ~700-800MB instead of 4.5GB)
-- Allows each test job to download and cache only the version it needs
-- Shares the TiUP binary cache across all tests for efficiency
-- Automatically cleans up unused caches after 7 days
+- Test the latest patch version for each selected major/minor database line.
+- Include every supported major/minor line that has not reached EOL.
+- Keep EOL major/minor lines in the matrix for two years after their EOL date.
+- Mark lines more than two years past EOL as red in `make eol-versions`; red rows
+  fail the CI matrix version policy check.
 
-This strategy balances test coverage with CI performance and reliability.
+The `make eol-versions` target checks the matrix against upstream release and EOL
+metadata. `make eol-versions-ci` applies the same check in CI and fails only when
+the status column contains a red row.

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/hashicorp/go-version v1.7.0
 	github.com/hashicorp/terraform-plugin-log v0.9.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.34.0
+	github.com/jedib0t/go-pretty/v6 v6.6.7
 	github.com/testcontainers/testcontainers-go v0.40.0
 	github.com/testcontainers/testcontainers-go/modules/mysql v0.40.0
 	github.com/tidwall/gjson v1.17.1
@@ -32,6 +33,7 @@ require (
 	github.com/agext/levenshtein v1.2.3 // indirect
 	github.com/apparentlymart/go-textseg/v15 v15.0.0 // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
+	github.com/clipperhouse/uax29/v2 v2.2.0 // indirect
 	github.com/cloudflare/circl v1.3.8 // indirect
 	github.com/containerd/errdefs v1.0.0 // indirect
 	github.com/containerd/errdefs/pkg v0.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -39,6 +39,8 @@ github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK3
 github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
+github.com/clipperhouse/uax29/v2 v2.2.0 h1:ChwIKnQN3kcZteTXMgb1wztSgaU+ZemkgWdohwgs8tY=
+github.com/clipperhouse/uax29/v2 v2.2.0/go.mod h1:EFJ2TJMRUaplDxHKj1qAEhCtQPW2tJSwu5BF98AuoVM=
 github.com/cloudflare/circl v1.3.8 h1:j+V8jJt09PoeMFIu2uh5JUyEaIHTXVOHslFoLNAKqwI=
 github.com/cloudflare/circl v1.3.8/go.mod h1:PDRU+oXvdD7KCtgKxW95M5Z8BpSCJXQORiZFnBQS5QU=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
@@ -212,6 +214,8 @@ github.com/jackc/puddle/v2 v2.2.1 h1:RhxXJtFG022u4ibrCSMSiu5aOq1i77R3OHKNJj77OAk
 github.com/jackc/puddle/v2 v2.2.1/go.mod h1:vriiEXHvEE654aYKXXjOvZM39qJ0q+azkZFrfEOc3H4=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
+github.com/jedib0t/go-pretty/v6 v6.6.7 h1:m+LbHpm0aIAPLzLbMfn8dc3Ht8MW7lsSO4MPItz/Uuo=
+github.com/jedib0t/go-pretty/v6 v6.6.7/go.mod h1:YwC5CE4fJ1HFUDeivSV1r//AmANFHyqczZk+U6BDALU=
 github.com/jhump/protoreflect v1.15.1 h1:HUMERORf3I3ZdX05WaQ6MIpd/NJ434hTp5YiKgfCL6c=
 github.com/jhump/protoreflect v1.15.1/go.mod h1:jD/2GMKKE6OqX8qTjhADU1e6DShO+gavG9e0Q693nKo=
 github.com/kevinburke/ssh_config v1.2.0 h1:x584FjTGwHzMwvHx18PXxbBVzfnxogHaAReU4gf13a4=

--- a/internal/testmatrix/matrix.go
+++ b/internal/testmatrix/matrix.go
@@ -26,6 +26,7 @@ const (
 	VersionMySQL57   = "5.7"
 	VersionPercona57 = "5.7"
 	VersionPercona80 = "8.0"
+	VersionPercona84 = "8.4"
 )
 
 type Entry struct {
@@ -41,19 +42,20 @@ type Entry struct {
 }
 
 var Entries = []Entry{
-	{Database: MySQL, Cycle: "5.7", Version: "5.7", DockerRepo: "library/mysql", EOLProduct: "mysql", EOLCycle: "5.7"},
-	{Database: MySQL, Cycle: "8.0", Version: "8.0", DockerRepo: "library/mysql", EOLProduct: "mysql", EOLCycle: "8.0"},
-	{Database: Percona, Cycle: "5.7", Version: "5.7", DockerRepo: "library/percona", BuildSuffix: true, EOLProduct: "mysql", EOLCycle: "5.7", EOLProxyFor: "Percona Server"},
-	{Database: Percona, Cycle: "8.0", Version: "8.0", DockerRepo: "percona/percona-server", BuildSuffix: true, EOLProduct: "mysql", EOLCycle: "8.0", EOLProxyFor: "Percona Server"},
-	{Database: MariaDB, Cycle: "10.3", Version: "10.3", DockerRepo: "library/mariadb", EOLProduct: "mariadb", EOLCycle: "10.3"},
-	{Database: MariaDB, Cycle: "10.8", Version: "10.8", DockerRepo: "library/mariadb", EOLProduct: "mariadb", EOLCycle: "10.8"},
-	{Database: MariaDB, Cycle: "10.10", Version: "10.10", DockerRepo: "library/mariadb", EOLProduct: "mariadb", EOLCycle: "10.10"},
+	{Database: MySQL, Cycle: "8.0", Version: "8.0.46", DockerRepo: "library/mysql", EOLProduct: "mysql", EOLCycle: "8.0"},
+	{Database: MySQL, Cycle: "8.4", Version: "8.4.9", DockerRepo: "library/mysql", EOLProduct: "mysql", EOLCycle: "8.4"},
+	{Database: MySQL, Cycle: "9.7", Version: "9.7.0", DockerRepo: "library/mysql", EOLProduct: "mysql", EOLCycle: "9.7"},
+	{Database: Percona, Cycle: "8.0", Version: "8.0.46-37", DockerRepo: "percona/percona-server", BuildSuffix: true, EOLProduct: "mysql", EOLCycle: "8.0", EOLProxyFor: "Percona Server"},
+	{Database: Percona, Cycle: "8.4", Version: "8.4.8-8", DockerRepo: "percona/percona-server", BuildSuffix: true, EOLProduct: "mysql", EOLCycle: "8.4", EOLProxyFor: "Percona Server"},
+	{Database: MariaDB, Cycle: "10.11", Version: "10.11.18", DockerRepo: "library/mariadb", EOLProduct: "mariadb", EOLCycle: "10.11"},
+	{Database: MariaDB, Cycle: "11.4", Version: "11.4.12", DockerRepo: "library/mariadb", EOLProduct: "mariadb", EOLCycle: "11.4"},
+	{Database: MariaDB, Cycle: "11.8", Version: "11.8.8", DockerRepo: "library/mariadb", EOLProduct: "mariadb", EOLCycle: "11.8"},
 	{Database: TiDB, Cycle: "6.1", Version: "6.1.7", DockerRepo: "pingcap/tidb", TagPrefix: "v"},
 	{Database: TiDB, Cycle: "6.5", Version: "6.5.12", DockerRepo: "pingcap/tidb", TagPrefix: "v"},
 	{Database: TiDB, Cycle: "7.1", Version: "7.1.6", DockerRepo: "pingcap/tidb", TagPrefix: "v"},
 	{Database: TiDB, Cycle: "7.5", Version: "7.5.7", DockerRepo: "pingcap/tidb", TagPrefix: "v"},
 	{Database: TiDB, Cycle: "8.1", Version: "8.1.2", DockerRepo: "pingcap/tidb", TagPrefix: "v"},
-	{Database: TiDB, Cycle: "8.5", Version: "8.5.5", DockerRepo: "pingcap/tidb", TagPrefix: "v"},
+	{Database: TiDB, Cycle: "8.5", Version: "8.5.6", DockerRepo: "pingcap/tidb", TagPrefix: "v"},
 }
 
 type GitHubActionsMatrix struct {
@@ -95,7 +97,7 @@ func (entry Entry) DockerImage() string {
 	case MySQL:
 		return ImageMySQLPrefix + entry.Version
 	case Percona:
-		if IsVersionInSeries(entry.Version, VersionPercona80) {
+		if UsesPerconaServerImage(entry.Version) {
 			return ImagePerconaServerPrefix + entry.Version
 		}
 		return ImagePerconaPrefix + entry.Version
@@ -113,7 +115,7 @@ func ImageForDBVersion(dbType, version string) (string, error) {
 	case MySQL.CLIName():
 		return ImageMySQLPrefix + version, nil
 	case Percona.CLIName():
-		if IsVersionInSeries(version, VersionPercona80) {
+		if UsesPerconaServerImage(version) {
 			return ImagePerconaServerPrefix + version, nil
 		}
 		return ImagePerconaPrefix + version, nil
@@ -129,7 +131,7 @@ func ImageForDBVersion(dbType, version string) (string, error) {
 func NormalizeImageAlias(image string) string {
 	if strings.HasPrefix(image, ImagePerconaPrefix) {
 		version := strings.TrimPrefix(image, ImagePerconaPrefix)
-		if IsVersionInSeries(version, VersionPercona80) {
+		if UsesPerconaServerImage(version) {
 			return ImagePerconaServerPrefix + version
 		}
 	}
@@ -153,6 +155,10 @@ func InferDatabaseAndDisplayImage(image string) (Database, string, error) {
 
 func IsVersionInSeries(version, series string) bool {
 	return version == series || strings.HasPrefix(version, series+".")
+}
+
+func UsesPerconaServerImage(version string) bool {
+	return IsVersionInSeries(version, VersionPercona80) || IsVersionInSeries(version, VersionPercona84)
 }
 
 func ImageIsInSeries(image, prefix, series string) bool {

--- a/internal/testmatrix/matrix.go
+++ b/internal/testmatrix/matrix.go
@@ -1,0 +1,207 @@
+package testmatrix
+
+import (
+	"fmt"
+	"strings"
+)
+
+type Database string
+
+const (
+	MySQL   Database = "mysql"
+	Percona Database = "percona"
+	MariaDB Database = "mariadb"
+	TiDB    Database = "tidb"
+)
+
+const (
+	ImageMySQLPrefix             = "mysql:"
+	ImagePerconaPrefix           = "percona:"
+	ImagePerconaRepoPrefix       = "percona/"
+	ImagePerconaServerPrefix     = "percona/percona-server:"
+	ImageDockerPerconaRepoPrefix = "docker.io/percona/"
+	ImageMariaDBPrefix           = "mariadb:"
+	ImageTiDBPrefix              = "tidb:"
+
+	VersionMySQL57   = "5.7"
+	VersionPercona57 = "5.7"
+	VersionPercona80 = "8.0"
+)
+
+type Entry struct {
+	Database    Database
+	Cycle       string
+	Version     string
+	DockerRepo  string
+	TagPrefix   string
+	BuildSuffix bool
+	EOLProduct  string
+	EOLCycle    string
+	EOLProxyFor string
+}
+
+var Entries = []Entry{
+	{Database: MySQL, Cycle: "5.7", Version: "5.7", DockerRepo: "library/mysql", EOLProduct: "mysql", EOLCycle: "5.7"},
+	{Database: MySQL, Cycle: "8.0", Version: "8.0", DockerRepo: "library/mysql", EOLProduct: "mysql", EOLCycle: "8.0"},
+	{Database: Percona, Cycle: "5.7", Version: "5.7", DockerRepo: "library/percona", BuildSuffix: true, EOLProduct: "mysql", EOLCycle: "5.7", EOLProxyFor: "Percona Server"},
+	{Database: Percona, Cycle: "8.0", Version: "8.0", DockerRepo: "percona/percona-server", BuildSuffix: true, EOLProduct: "mysql", EOLCycle: "8.0", EOLProxyFor: "Percona Server"},
+	{Database: MariaDB, Cycle: "10.3", Version: "10.3", DockerRepo: "library/mariadb", EOLProduct: "mariadb", EOLCycle: "10.3"},
+	{Database: MariaDB, Cycle: "10.8", Version: "10.8", DockerRepo: "library/mariadb", EOLProduct: "mariadb", EOLCycle: "10.8"},
+	{Database: MariaDB, Cycle: "10.10", Version: "10.10", DockerRepo: "library/mariadb", EOLProduct: "mariadb", EOLCycle: "10.10"},
+	{Database: TiDB, Cycle: "6.1", Version: "6.1.7", DockerRepo: "pingcap/tidb", TagPrefix: "v"},
+	{Database: TiDB, Cycle: "6.5", Version: "6.5.12", DockerRepo: "pingcap/tidb", TagPrefix: "v"},
+	{Database: TiDB, Cycle: "7.1", Version: "7.1.6", DockerRepo: "pingcap/tidb", TagPrefix: "v"},
+	{Database: TiDB, Cycle: "7.5", Version: "7.5.7", DockerRepo: "pingcap/tidb", TagPrefix: "v"},
+	{Database: TiDB, Cycle: "8.1", Version: "8.1.2", DockerRepo: "pingcap/tidb", TagPrefix: "v"},
+	{Database: TiDB, Cycle: "8.5", Version: "8.5.5", DockerRepo: "pingcap/tidb", TagPrefix: "v"},
+}
+
+type GitHubActionsMatrix struct {
+	Include []GitHubActionsEntry `json:"include"`
+}
+
+type GitHubActionsEntry struct {
+	DBType     string `json:"db_type"`
+	DBVersion  string `json:"db_version"`
+	MakeTarget string `json:"make_target"`
+}
+
+func All() []Entry {
+	entries := make([]Entry, len(Entries))
+	copy(entries, Entries)
+	return entries
+}
+
+func ActionsMatrix() GitHubActionsMatrix {
+	entries := All()
+	matrix := GitHubActionsMatrix{Include: make([]GitHubActionsEntry, 0, len(entries))}
+	for _, entry := range entries {
+		matrix.Include = append(matrix.Include, GitHubActionsEntry{
+			DBType:     entry.Database.CLIName(),
+			DBVersion:  entry.Version,
+			MakeTarget: entry.MakeTarget(),
+		})
+	}
+	return matrix
+}
+
+func (entry Entry) DisplayImage() string {
+	if entry.Database == TiDB {
+		return entry.Version
+	}
+	return entry.DockerImage()
+}
+
+func (entry Entry) DockerImage() string {
+	switch entry.Database {
+	case MySQL:
+		return ImageMySQLPrefix + entry.Version
+	case Percona:
+		if IsVersionInSeries(entry.Version, VersionPercona80) {
+			return ImagePerconaServerPrefix + entry.Version
+		}
+		return ImagePerconaPrefix + entry.Version
+	case MariaDB:
+		return ImageMariaDBPrefix + entry.Version
+	case TiDB:
+		return ImageTiDBPrefix + entry.Version
+	default:
+		return entry.Database.CLIName() + ":" + entry.Version
+	}
+}
+
+func (entry Entry) MakeTarget() string {
+	return fmt.Sprintf("test-%s-%s", entry.Database.CLIName(), entry.Version)
+}
+
+func ImageForDBVersion(dbType, version string) (string, error) {
+	switch strings.ToLower(dbType) {
+	case MySQL.CLIName():
+		return ImageMySQLPrefix + version, nil
+	case Percona.CLIName():
+		if IsVersionInSeries(version, VersionPercona80) {
+			return ImagePerconaServerPrefix + version, nil
+		}
+		return ImagePerconaPrefix + version, nil
+	case MariaDB.CLIName():
+		return ImageMariaDBPrefix + version, nil
+	case TiDB.CLIName():
+		return ImageTiDBPrefix + version, nil
+	default:
+		return "", fmt.Errorf("unsupported database type %q", dbType)
+	}
+}
+
+func NormalizeImageAlias(image string) string {
+	if strings.HasPrefix(image, ImagePerconaPrefix) {
+		version := strings.TrimPrefix(image, ImagePerconaPrefix)
+		if IsVersionInSeries(version, VersionPercona80) {
+			return ImagePerconaServerPrefix + version
+		}
+	}
+	return image
+}
+
+func InferDatabaseAndDisplayImage(image string) (Database, string, error) {
+	switch {
+	case strings.HasPrefix(image, ImageMySQLPrefix):
+		return MySQL, image, nil
+	case strings.HasPrefix(image, ImagePerconaPrefix) || strings.HasPrefix(image, ImagePerconaRepoPrefix) || strings.HasPrefix(image, ImageDockerPerconaRepoPrefix):
+		return Percona, image, nil
+	case strings.HasPrefix(image, ImageMariaDBPrefix):
+		return MariaDB, image, nil
+	case strings.HasPrefix(image, ImageTiDBPrefix):
+		return TiDB, strings.TrimPrefix(image, ImageTiDBPrefix), nil
+	default:
+		return "", "", fmt.Errorf("could not infer database type from image %q", image)
+	}
+}
+
+func IsVersionInSeries(version, series string) bool {
+	return version == series || strings.HasPrefix(version, series+".")
+}
+
+func ImageIsInSeries(image, prefix, series string) bool {
+	if !strings.HasPrefix(image, prefix) {
+		return false
+	}
+	return IsVersionInSeries(strings.TrimPrefix(image, prefix), series)
+}
+
+func (db Database) CLIName() string {
+	return string(db)
+}
+
+func (db Database) Label() string {
+	switch db {
+	case MySQL:
+		return "MySQL"
+	case Percona:
+		return "Percona"
+	case MariaDB:
+		return "MariaDB"
+	case TiDB:
+		return "TiDB"
+	default:
+		return string(db)
+	}
+}
+
+func (db Database) ConstName() string {
+	switch db {
+	case MySQL:
+		return "MySQL"
+	case Percona:
+		return "Percona"
+	case MariaDB:
+		return "MariaDB"
+	case TiDB:
+		return "TiDB"
+	default:
+		return string(db)
+	}
+}
+
+func (db Database) String() string {
+	return db.Label()
+}

--- a/internal/testmatrix/matrix.go
+++ b/internal/testmatrix/matrix.go
@@ -61,9 +61,8 @@ type GitHubActionsMatrix struct {
 }
 
 type GitHubActionsEntry struct {
-	DBType     string `json:"db_type"`
-	DBVersion  string `json:"db_version"`
-	MakeTarget string `json:"make_target"`
+	DBType    string `json:"db_type"`
+	DBVersion string `json:"db_version"`
 }
 
 func All() []Entry {
@@ -77,9 +76,8 @@ func ActionsMatrix() GitHubActionsMatrix {
 	matrix := GitHubActionsMatrix{Include: make([]GitHubActionsEntry, 0, len(entries))}
 	for _, entry := range entries {
 		matrix.Include = append(matrix.Include, GitHubActionsEntry{
-			DBType:     entry.Database.CLIName(),
-			DBVersion:  entry.Version,
-			MakeTarget: entry.MakeTarget(),
+			DBType:    entry.Database.CLIName(),
+			DBVersion: entry.Version,
 		})
 	}
 	return matrix
@@ -108,10 +106,6 @@ func (entry Entry) DockerImage() string {
 	default:
 		return entry.Database.CLIName() + ":" + entry.Version
 	}
-}
-
-func (entry Entry) MakeTarget() string {
-	return fmt.Sprintf("test-%s-%s", entry.Database.CLIName(), entry.Version)
 }
 
 func ImageForDBVersion(dbType, version string) (string, error) {

--- a/internal/testmatrix/matrix_test.go
+++ b/internal/testmatrix/matrix_test.go
@@ -41,9 +41,15 @@ func TestEntryImages(t *testing.T) {
 		},
 		{
 			name:        "percona 8 uses native image",
-			entry:       Entry{Database: Percona, Version: "8.0"},
-			wantDisplay: "percona/percona-server:8.0",
-			wantDocker:  "percona/percona-server:8.0",
+			entry:       Entry{Database: Percona, Version: "8.0.46-37"},
+			wantDisplay: "percona/percona-server:8.0.46-37",
+			wantDocker:  "percona/percona-server:8.0.46-37",
+		},
+		{
+			name:        "percona 8.4 uses native image",
+			entry:       Entry{Database: Percona, Version: "8.4.8-8"},
+			wantDisplay: "percona/percona-server:8.4.8-8",
+			wantDocker:  "percona/percona-server:8.4.8-8",
 		},
 		{
 			name:        "tidb displays version",

--- a/internal/testmatrix/matrix_test.go
+++ b/internal/testmatrix/matrix_test.go
@@ -1,0 +1,75 @@
+package testmatrix
+
+import "testing"
+
+func TestActionsMatrixUsesSingleEntrySource(t *testing.T) {
+	matrix := ActionsMatrix()
+	entries := All()
+	if len(matrix.Include) != len(entries) {
+		t.Fatalf("got %d matrix rows, want %d", len(matrix.Include), len(entries))
+	}
+
+	seenTargets := map[string]bool{}
+	for i, row := range matrix.Include {
+		entry := entries[i]
+		if row.DBType != entry.Database.CLIName() {
+			t.Fatalf("row %d db_type = %q, want %q", i, row.DBType, entry.Database.CLIName())
+		}
+		if row.DBVersion != entry.Version {
+			t.Fatalf("row %d db_version = %q, want %q", i, row.DBVersion, entry.Version)
+		}
+		if row.MakeTarget != entry.MakeTarget() {
+			t.Fatalf("row %d make_target = %q, want %q", i, row.MakeTarget, entry.MakeTarget())
+		}
+		if seenTargets[row.MakeTarget] {
+			t.Fatalf("duplicate make target %q", row.MakeTarget)
+		}
+		seenTargets[row.MakeTarget] = true
+	}
+}
+
+func TestEntryImages(t *testing.T) {
+	tests := []struct {
+		name        string
+		entry       Entry
+		wantDisplay string
+		wantDocker  string
+		wantMake    string
+	}{
+		{
+			name:        "mysql",
+			entry:       Entry{Database: MySQL, Version: "8.0"},
+			wantDisplay: "mysql:8.0",
+			wantDocker:  "mysql:8.0",
+			wantMake:    "test-mysql-8.0",
+		},
+		{
+			name:        "percona 8 uses native image",
+			entry:       Entry{Database: Percona, Version: "8.0"},
+			wantDisplay: "percona/percona-server:8.0",
+			wantDocker:  "percona/percona-server:8.0",
+			wantMake:    "test-percona-8.0",
+		},
+		{
+			name:        "tidb displays version",
+			entry:       Entry{Database: TiDB, Version: "8.5.5"},
+			wantDisplay: "8.5.5",
+			wantDocker:  "tidb:8.5.5",
+			wantMake:    "test-tidb-8.5.5",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.entry.DisplayImage(); got != tt.wantDisplay {
+				t.Fatalf("DisplayImage() = %q, want %q", got, tt.wantDisplay)
+			}
+			if got := tt.entry.DockerImage(); got != tt.wantDocker {
+				t.Fatalf("DockerImage() = %q, want %q", got, tt.wantDocker)
+			}
+			if got := tt.entry.MakeTarget(); got != tt.wantMake {
+				t.Fatalf("MakeTarget() = %q, want %q", got, tt.wantMake)
+			}
+		})
+	}
+}

--- a/internal/testmatrix/matrix_test.go
+++ b/internal/testmatrix/matrix_test.go
@@ -18,13 +18,11 @@ func TestActionsMatrixUsesSingleEntrySource(t *testing.T) {
 		if row.DBVersion != entry.Version {
 			t.Fatalf("row %d db_version = %q, want %q", i, row.DBVersion, entry.Version)
 		}
-		if row.MakeTarget != entry.MakeTarget() {
-			t.Fatalf("row %d make_target = %q, want %q", i, row.MakeTarget, entry.MakeTarget())
+		key := row.DBType + ":" + row.DBVersion
+		if seenTargets[key] {
+			t.Fatalf("duplicate matrix row %q", key)
 		}
-		if seenTargets[row.MakeTarget] {
-			t.Fatalf("duplicate make target %q", row.MakeTarget)
-		}
-		seenTargets[row.MakeTarget] = true
+		seenTargets[key] = true
 	}
 }
 
@@ -34,28 +32,24 @@ func TestEntryImages(t *testing.T) {
 		entry       Entry
 		wantDisplay string
 		wantDocker  string
-		wantMake    string
 	}{
 		{
 			name:        "mysql",
 			entry:       Entry{Database: MySQL, Version: "8.0"},
 			wantDisplay: "mysql:8.0",
 			wantDocker:  "mysql:8.0",
-			wantMake:    "test-mysql-8.0",
 		},
 		{
 			name:        "percona 8 uses native image",
 			entry:       Entry{Database: Percona, Version: "8.0"},
 			wantDisplay: "percona/percona-server:8.0",
 			wantDocker:  "percona/percona-server:8.0",
-			wantMake:    "test-percona-8.0",
 		},
 		{
 			name:        "tidb displays version",
 			entry:       Entry{Database: TiDB, Version: "8.5.5"},
 			wantDisplay: "8.5.5",
 			wantDocker:  "tidb:8.5.5",
-			wantMake:    "test-tidb-8.5.5",
 		},
 	}
 
@@ -66,9 +60,6 @@ func TestEntryImages(t *testing.T) {
 			}
 			if got := tt.entry.DockerImage(); got != tt.wantDocker {
 				t.Fatalf("DockerImage() = %q, want %q", got, tt.wantDocker)
-			}
-			if got := tt.entry.MakeTarget(); got != tt.wantMake {
-				t.Fatalf("MakeTarget() = %q, want %q", got, tt.wantMake)
 			}
 		})
 	}

--- a/mysql/provider_unit_test.go
+++ b/mysql/provider_unit_test.go
@@ -1,0 +1,9 @@
+package mysql
+
+import "testing"
+
+func TestProviderInternalValidate(t *testing.T) {
+	if err := Provider().InternalValidate(); err != nil {
+		t.Fatalf("provider validation failed: %s", err)
+	}
+}

--- a/mysql/resource_grant.go
+++ b/mysql/resource_grant.go
@@ -854,7 +854,7 @@ func parseDatabaseQualifiedObject(objectRef string) (string, string, error) {
 }
 
 var (
-	kRequireRegex = regexp.MustCompile(`.*REQUIRE\s+(.*)`)
+	kRequireRegex = regexp.MustCompile(`.*\bREQUIRE\s+(.+?)(?:\s+WITH\s+(?:GRANT|ADMIN)\s+OPTION)?$`)
 
 	kGrantRegex = regexp.MustCompile(`\bGRANT OPTION\b|\bADMIN OPTION\b`)
 

--- a/mysql/resource_grant_unit_test.go
+++ b/mysql/resource_grant_unit_test.go
@@ -1,0 +1,189 @@
+package mysql
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func TestNormalizePerms(t *testing.T) {
+	got := normalizePerms([]string{
+		"`select (b, a)`",
+		"USAGE",
+		"allprivileges",
+		"INSERT(c3, c1)",
+	})
+	want := []string{
+		"ALL PRIVILEGES",
+		"INSERT(C1, C3)",
+		"SELECT(A, B)",
+	}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("normalizePerms() = %#v, want %#v", got, want)
+	}
+}
+
+func TestParseGrantFromRowTableGrant(t *testing.T) {
+	grant, err := parseGrantFromRow("GRANT SELECT, INSERT(c2, c1) ON `app_db`.`accounts` TO 'app'@'%' REQUIRE SSL WITH GRANT OPTION")
+	if err != nil {
+		t.Fatalf("parseGrantFromRow returned error: %s", err)
+	}
+
+	tableGrant, ok := grant.(*TablePrivilegeGrant)
+	if !ok {
+		t.Fatalf("parseGrantFromRow returned %T, want *TablePrivilegeGrant", grant)
+	}
+
+	if tableGrant.Database != "app_db" {
+		t.Fatalf("Database = %q, want %q", tableGrant.Database, "app_db")
+	}
+	if tableGrant.Table != "accounts" {
+		t.Fatalf("Table = %q, want %q", tableGrant.Table, "accounts")
+	}
+	if !reflect.DeepEqual(tableGrant.Privileges, []string{"INSERT(C1, C2)", "SELECT"}) {
+		t.Fatalf("Privileges = %#v", tableGrant.Privileges)
+	}
+	if !tableGrant.Grant {
+		t.Fatal("Grant = false, want true")
+	}
+	if tableGrant.TLSOption != "SSL" {
+		t.Fatalf("TLSOption = %q", tableGrant.TLSOption)
+	}
+	if !tableGrant.UserOrRole.Equals(UserOrRole{Name: "app", Host: "%"}) {
+		t.Fatalf("UserOrRole = %#v", tableGrant.UserOrRole)
+	}
+}
+
+func TestParseGrantFromRowProcedureGrant(t *testing.T) {
+	grant, err := parseGrantFromRow("GRANT EXECUTE ON PROCEDURE `app_db`.`rotate_keys` TO 'app'@'localhost'")
+	if err != nil {
+		t.Fatalf("parseGrantFromRow returned error: %s", err)
+	}
+
+	procedureGrant, ok := grant.(*ProcedurePrivilegeGrant)
+	if !ok {
+		t.Fatalf("parseGrantFromRow returned %T, want *ProcedurePrivilegeGrant", grant)
+	}
+
+	if procedureGrant.ObjectT != kProcedure {
+		t.Fatalf("ObjectT = %q, want %q", procedureGrant.ObjectT, kProcedure)
+	}
+	if procedureGrant.Database != "app_db" {
+		t.Fatalf("Database = %q, want %q", procedureGrant.Database, "app_db")
+	}
+	if procedureGrant.CallableName != "rotate_keys" {
+		t.Fatalf("CallableName = %q, want %q", procedureGrant.CallableName, "rotate_keys")
+	}
+	if !reflect.DeepEqual(procedureGrant.Privileges, []string{"EXECUTE"}) {
+		t.Fatalf("Privileges = %#v", procedureGrant.Privileges)
+	}
+}
+
+func TestParseGrantFromRowRoleGrant(t *testing.T) {
+	grant, err := parseGrantFromRow("GRANT `writer`, `reader` TO 'app'@'localhost' WITH ADMIN OPTION")
+	if err != nil {
+		t.Fatalf("parseGrantFromRow returned error: %s", err)
+	}
+
+	roleGrant, ok := grant.(*RoleGrant)
+	if !ok {
+		t.Fatalf("parseGrantFromRow returned %T, want *RoleGrant", grant)
+	}
+
+	if !reflect.DeepEqual(roleGrant.Roles, []string{"writer", "reader"}) {
+		t.Fatalf("Roles = %#v", roleGrant.Roles)
+	}
+	if !roleGrant.Grant {
+		t.Fatal("Grant = false, want true")
+	}
+	if !roleGrant.UserOrRole.Equals(UserOrRole{Name: "app", Host: "localhost"}) {
+		t.Fatalf("UserOrRole = %#v", roleGrant.UserOrRole)
+	}
+}
+
+func TestParseGrantFromRowSkipsPartialRevoke(t *testing.T) {
+	grant, err := parseGrantFromRow("REVOKE INSERT ON `app_db`.`accounts` FROM 'app'@'%'")
+	if err != nil {
+		t.Fatalf("parseGrantFromRow returned error: %s", err)
+	}
+	if grant != nil {
+		t.Fatalf("grant = %#v, want nil", grant)
+	}
+}
+
+func TestTablePrivilegeGrantSQLStatements(t *testing.T) {
+	grant := &TablePrivilegeGrant{
+		Database:   "app_db",
+		Table:      "accounts",
+		Privileges: []string{"SELECT", "UPDATE(c1, c2)"},
+		Grant:      true,
+		UserOrRole: UserOrRole{Name: "app", Host: "%"},
+		TLSOption:  "SSL",
+	}
+
+	wantGrant := "GRANT SELECT, UPDATE(c1, c2) ON `app_db`.`accounts` TO 'app'@'%' REQUIRE SSL WITH GRANT OPTION"
+	if got := grant.SQLGrantStatement(); got != wantGrant {
+		t.Fatalf("SQLGrantStatement() = %q, want %q", got, wantGrant)
+	}
+
+	wantRevoke := "REVOKE SELECT, UPDATE(c1, c2), GRANT OPTION ON `app_db`.`accounts` FROM 'app'@'%'"
+	if got := grant.SQLRevokeStatement(); got != wantRevoke {
+		t.Fatalf("SQLRevokeStatement() = %q, want %q", got, wantRevoke)
+	}
+}
+
+func TestParseResourceFromDataTableGrant(t *testing.T) {
+	d := schema.TestResourceDataRaw(t, resourceGrant().Schema, map[string]interface{}{
+		"user":       "app",
+		"host":       "%",
+		"database":   "app_db",
+		"table":      "accounts",
+		"privileges": []interface{}{"update(c2, c1)", "select"},
+		"grant":      true,
+		"tls_option": "SSL",
+	})
+
+	grant, diagErr := parseResourceFromData(d)
+	if diagErr.HasError() {
+		t.Fatalf("parseResourceFromData returned diagnostics: %s", diagErr[0].Summary)
+	}
+
+	tableGrant, ok := grant.(*TablePrivilegeGrant)
+	if !ok {
+		t.Fatalf("parseResourceFromData returned %T, want *TablePrivilegeGrant", grant)
+	}
+	if !reflect.DeepEqual(tableGrant.Privileges, []string{"SELECT", "UPDATE(C1, C2)"}) {
+		t.Fatalf("Privileges = %#v", tableGrant.Privileges)
+	}
+	if got := tableGrant.SQLGrantStatement(); got != "GRANT SELECT, UPDATE(C1, C2) ON `app_db`.`accounts` TO 'app'@'%' REQUIRE SSL WITH GRANT OPTION" {
+		t.Fatalf("SQLGrantStatement() = %q", got)
+	}
+}
+
+func TestParseResourceFromDataRoleGrant(t *testing.T) {
+	d := schema.TestResourceDataRaw(t, resourceGrant().Schema, map[string]interface{}{
+		"role":       "app_role",
+		"database":   "*",
+		"roles":      []interface{}{"writer", "reader"},
+		"grant":      true,
+		"tls_option": "NONE",
+	})
+
+	grant, diagErr := parseResourceFromData(d)
+	if diagErr.HasError() {
+		t.Fatalf("parseResourceFromData returned diagnostics: %s", diagErr[0].Summary)
+	}
+
+	roleGrant, ok := grant.(*RoleGrant)
+	if !ok {
+		t.Fatalf("parseResourceFromData returned %T, want *RoleGrant", grant)
+	}
+	roles := append([]string(nil), roleGrant.Roles...)
+	sort.Strings(roles)
+	if !reflect.DeepEqual(roles, []string{"reader", "writer"}) {
+		t.Fatalf("Roles = %#v", roleGrant.Roles)
+	}
+}

--- a/mysql/resource_ti_config_variable_test.go
+++ b/mysql/resource_ti_config_variable_test.go
@@ -14,6 +14,8 @@ import (
 )
 
 func TestPdConfigVar_basic(t *testing.T) {
+	skipIfAcceptanceTestsDisabled(t)
+
 	varName := "log.level"
 	varValue := "warn"
 	varType := "pd"
@@ -87,6 +89,8 @@ func TestPdConfigVar_basic(t *testing.T) {
 }
 
 func TestTiKvConfigVar_basic(t *testing.T) {
+	skipIfAcceptanceTestsDisabled(t)
+
 	varName := "split.qps-threshold"
 	varValue := "1000"
 	varType := "tikv"
@@ -126,6 +130,14 @@ func TestTiKvConfigVar_basic(t *testing.T) {
 			},
 		},
 	})
+}
+
+func skipIfAcceptanceTestsDisabled(t *testing.T) {
+	t.Helper()
+
+	if os.Getenv(resource.EnvTfAcc) == "" {
+		t.Skipf("Acceptance tests skipped unless env %q set", resource.EnvTfAcc)
+	}
 }
 
 func testAccConfigVarExists(varName string, varValue string, varType string) resource.TestCheckFunc {

--- a/mysql/resource_ti_placement_policy_unit_test.go
+++ b/mysql/resource_ti_placement_policy_unit_test.go
@@ -1,0 +1,84 @@
+package mysql
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func TestPlacementPolicyBuildSQLQuery(t *testing.T) {
+	pp := PlacementPolicy{
+		Name:          "policy1",
+		PrimaryRegion: "us-east-1",
+		Regions:       []string{"us-east-1", "us-west-2"},
+		Constraints:   []string{"+zone=us-east-1", "+disk=ssd"},
+	}
+
+	got := pp.buildSQLQuery(CreatePlacementPolicySQLPrefix)
+	want := `CREATE PLACEMENT POLICY IF NOT EXISTS policy1 PRIMARY_REGION="us-east-1" REGIONS="us-east-1,us-west-2" CONSTRAINTS="[+zone=us-east-1,+disk=ssd]" ;`
+	if got != want {
+		t.Fatalf("buildSQLQuery() = %q, want %q", got, want)
+	}
+}
+
+func TestPlacementPolicyBuildSQLQueryEmptyConstraints(t *testing.T) {
+	pp := PlacementPolicy{Name: "policy1"}
+
+	got := pp.buildSQLQuery(UpdatePlacementPolicySQLPrefix)
+	want := `ALTER PLACEMENT POLICY policy1 CONSTRAINTS="" ;`
+	if got != want {
+		t.Fatalf("buildSQLQuery() = %q, want %q", got, want)
+	}
+}
+
+func TestPlacementPolicyResourceDataMapping(t *testing.T) {
+	d := schema.TestResourceDataRaw(t, resourceTiPlacementPolicy().Schema, map[string]interface{}{
+		"name":           "policy1",
+		"primary_region": "us-east-1",
+		"regions":        []interface{}{"us-east-1", "us-west-2"},
+		"constraints":    []interface{}{"+zone=us-east-1", "+disk=ssd"},
+	})
+
+	pp := NewPlacementPolicyFromResourceData(d)
+	if pp.Name != "policy1" {
+		t.Fatalf("Name = %q", pp.Name)
+	}
+	if pp.PrimaryRegion != "us-east-1" {
+		t.Fatalf("PrimaryRegion = %q", pp.PrimaryRegion)
+	}
+	if !reflect.DeepEqual(pp.Regions, []string{"us-east-1", "us-west-2"}) {
+		t.Fatalf("Regions = %#v", pp.Regions)
+	}
+	if !reflect.DeepEqual(pp.Constraints, []string{"+zone=us-east-1", "+disk=ssd"}) {
+		t.Fatalf("Constraints = %#v", pp.Constraints)
+	}
+
+	setPlacementPolicyOnResourceData(PlacementPolicy{
+		Name:          "policy2",
+		PrimaryRegion: "us-west-2",
+		Regions:       []string{"us-west-2"},
+		Constraints:   []string{"+zone=us-west-2"},
+	}, d)
+
+	if got := d.Get("name").(string); got != "policy2" {
+		t.Fatalf("resource data name = %q", got)
+	}
+	if got := d.Get("primary_region").(string); got != "us-west-2" {
+		t.Fatalf("resource data primary_region = %q", got)
+	}
+	if got := expandStringList(d.Get("regions").([]interface{})); !reflect.DeepEqual(got, []string{"us-west-2"}) {
+		t.Fatalf("resource data regions = %#v", got)
+	}
+	if got := expandStringList(d.Get("constraints").([]interface{})); !reflect.DeepEqual(got, []string{"+zone=us-west-2"}) {
+		t.Fatalf("resource data constraints = %#v", got)
+	}
+}
+
+func expandStringList(values []interface{}) []string {
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		out = append(out, value.(string))
+	}
+	return out
+}

--- a/mysql/resource_ti_resource_group_unit_test.go
+++ b/mysql/resource_ti_resource_group_unit_test.go
@@ -1,0 +1,89 @@
+package mysql
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func TestResourceGroupBuildSQLQuery(t *testing.T) {
+	rg := ResourceGroup{
+		Name:          "rg100",
+		ResourceUnits: 2000000,
+		Priority:      "HIGH",
+		Burstable:     true,
+		QueryLimit:    "EXEC_ELAPSED='15s', ACTION=COOLDOWN, WATCH=SIMILAR DURATION='10m0s'",
+	}
+
+	got := rg.buildSQLQuery(UpdateResourceGroupSQLPrefix)
+	want := "ALTER RESOURCE GROUP rg100 RU_PER_SEC = 2000000 PRIORITY = HIGH QUERY_LIMIT=(EXEC_ELAPSED='15s', ACTION=COOLDOWN, WATCH=SIMILAR DURATION='10m0s') BURSTABLE = true ;"
+	if got != want {
+		t.Fatalf("buildSQLQuery() = %q, want %q", got, want)
+	}
+}
+
+func TestResourceGroupBuildSQLQueryEmptyQueryLimit(t *testing.T) {
+	rg := ResourceGroup{
+		Name:          "rg100",
+		ResourceUnits: 100,
+		Priority:      "LOW",
+		Burstable:     false,
+	}
+
+	got := rg.buildSQLQuery(CreateResourceGroupSQLPrefix)
+	want := "CREATE RESOURCE GROUP IF NOT EXISTS rg100 RU_PER_SEC = 100 PRIORITY = LOW QUERY_LIMIT=NULL BURSTABLE = false ;"
+	if got != want {
+		t.Fatalf("buildSQLQuery() = %q, want %q", got, want)
+	}
+}
+
+func TestResourceGroupResourceDataMapping(t *testing.T) {
+	d := schema.TestResourceDataRaw(t, resourceTiResourceGroup().Schema, map[string]interface{}{
+		"name":           "rg100",
+		"resource_units": 100,
+		"priority":       "low",
+		"burstable":      true,
+		"query_limit":    "",
+	})
+
+	rg := NewResourceGroupFromResourceData(d)
+	if rg.Name != "rg100" {
+		t.Fatalf("Name = %q", rg.Name)
+	}
+	if rg.ResourceUnits != 100 {
+		t.Fatalf("ResourceUnits = %d", rg.ResourceUnits)
+	}
+	if rg.Priority != "LOW" {
+		t.Fatalf("Priority = %q, want LOW", rg.Priority)
+	}
+	if !rg.Burstable {
+		t.Fatal("Burstable = false, want true")
+	}
+	if rg.QueryLimit != "" {
+		t.Fatalf("QueryLimit = %q", rg.QueryLimit)
+	}
+
+	setResourceGroupOnResourceData(ResourceGroup{
+		Name:          "rg200",
+		ResourceUnits: 200,
+		Priority:      "medium",
+		Burstable:     false,
+		QueryLimit:    "EXEC_ELAPSED='15s'",
+	}, d)
+
+	if got := d.Get("name").(string); got != "rg200" {
+		t.Fatalf("resource data name = %q", got)
+	}
+	if got := d.Get("resource_units").(int); got != 200 {
+		t.Fatalf("resource data resource_units = %d", got)
+	}
+	if got := d.Get("priority").(string); got != "medium" {
+		t.Fatalf("resource data priority = %q", got)
+	}
+	if got := d.Get("burstable").(bool); got {
+		t.Fatal("resource data burstable = true, want false")
+	}
+	if got := d.Get("query_limit").(string); got != "EXEC_ELAPSED='15s'" {
+		t.Fatalf("resource data query_limit = %q", got)
+	}
+}

--- a/scripts/test-matrix.go
+++ b/scripts/test-matrix.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/zph/terraform-provider-mysql/v3/internal/testmatrix"
+)
+
+func main() {
+	githubActions := flag.Bool("github-actions", false, "emit GitHub Actions strategy matrix JSON")
+	flag.Parse()
+
+	if !*githubActions {
+		fmt.Fprintln(os.Stderr, "ERROR: pass --github-actions")
+		os.Exit(2)
+	}
+
+	payload, err := json.Marshal(testmatrix.ActionsMatrix())
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "ERROR: marshal test matrix: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Println(string(payload))
+}

--- a/scripts/test-runner.go
+++ b/scripts/test-runner.go
@@ -11,46 +11,17 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/zph/terraform-provider-mysql/v3/internal/testmatrix"
 )
 
-var (
-	// MySQL versions to test
-	mysqlVersions = []string{
-		imageMySQL57,
-		imageMySQL80,
-	}
-
-	// Percona versions to test
-	perconaVersions = []string{
-		imagePercona57,
-		imagePercona80Native,
-	}
-
-	// MariaDB versions to test
-	mariadbVersions = []string{
-		imageMariaDB103,
-		imageMariaDB108,
-		imageMariaDB1010,
-	}
-
-	// TiDB versions to test (version numbers only, not full image names)
-	tidbVersions = []string{
-		versionTiDB617,
-		versionTiDB6512,
-		versionTiDB716,
-		versionTiDB757,
-		versionTiDB812,
-		versionTiDB855,
-	}
-)
-
-type databaseType string
+type databaseType = testmatrix.Database
 
 const (
-	dbMySQL   databaseType = "MySQL"
-	dbPercona databaseType = "Percona"
-	dbMariaDB databaseType = "MariaDB"
-	dbTiDB    databaseType = "TiDB"
+	dbMySQL   = testmatrix.MySQL
+	dbPercona = testmatrix.Percona
+	dbMariaDB = testmatrix.MariaDB
+	dbTiDB    = testmatrix.TiDB
 )
 
 const (
@@ -65,37 +36,6 @@ const (
 	defaultTestTimeout = "15m"
 	defaultTestPattern = runAllTestPattern
 	runAllTestPattern  = "."
-)
-
-const (
-	imageMySQLPrefix             = "mysql:"
-	imagePerconaPrefix           = "percona:"
-	imagePerconaRepoPrefix       = "percona/"
-	imagePerconaServerPrefix     = "percona/percona-server:"
-	imageDockerPerconaRepoPrefix = "docker.io/percona/"
-	imageMariaDBPrefix           = "mariadb:"
-	imageTiDBPrefix              = "tidb:"
-
-	imageMySQL57         = "mysql:5.7"
-	imageMySQL80         = "mysql:8.0"
-	imagePercona57       = "percona:5.7"
-	imagePercona80Alias  = "percona:8.0"
-	imagePercona80Native = "percona/percona-server:8.0"
-	imageMariaDB103      = "mariadb:10.3"
-	imageMariaDB108      = "mariadb:10.8"
-	imageMariaDB1010     = "mariadb:10.10"
-)
-
-const (
-	versionPercona80 = "8.0"
-	versionMySQL57   = "5.7"
-	versionPercona57 = "5.7"
-	versionTiDB617   = "6.1.7"
-	versionTiDB6512  = "6.5.12"
-	versionTiDB716   = "7.1.6"
-	versionTiDB757   = "7.5.7"
-	versionTiDB812   = "8.1.2"
-	versionTiDB855   = "8.5.5"
 )
 
 const (
@@ -301,29 +241,14 @@ func matrixJobs(cfg testRunnerConfig) ([]testJob, []testResult) {
 	var skippedResults []testResult
 	testNum := 0
 
-	for _, image := range mysqlVersions {
+	for _, entry := range testmatrix.All() {
 		testNum++
-		jobs = append(jobs, newTestJob(dbMySQL, image, image, cfg, testNum))
-	}
-
-	for _, image := range perconaVersions {
-		testNum++
-		job := newTestJob(dbPercona, image, image, cfg, testNum)
+		job := newTestJob(entry.Database, entry.DisplayImage(), entry.DockerImage(), cfg, testNum)
 		if skipped, ok := skipResult(job); ok {
 			skippedResults = append(skippedResults, *skipped)
 			continue
 		}
 		jobs = append(jobs, job)
-	}
-
-	for _, image := range mariadbVersions {
-		testNum++
-		jobs = append(jobs, newTestJob(dbMariaDB, image, image, cfg, testNum))
-	}
-
-	for _, version := range tidbVersions {
-		testNum++
-		jobs = append(jobs, newTestJob(dbTiDB, version, imageTiDBPrefix+version, cfg, testNum))
 	}
 
 	return jobs, skippedResults
@@ -351,21 +276,7 @@ func skipResult(job testJob) (*testResult, bool) {
 }
 
 func imageForDBVersion(dbType, version string) (string, error) {
-	switch strings.ToLower(dbType) {
-	case cliDBMySQL:
-		return imageMySQLPrefix + version, nil
-	case cliDBPercona:
-		if isVersionInSeries(version, versionPercona80) {
-			return imagePerconaServerPrefix + version, nil
-		}
-		return imagePerconaPrefix + version, nil
-	case cliDBMariaDB:
-		return imageMariaDBPrefix + version, nil
-	case cliDBTiDB:
-		return imageTiDBPrefix + version, nil
-	default:
-		return "", fmt.Errorf("unsupported database type %q", dbType)
-	}
+	return testmatrix.ImageForDBVersion(dbType, version)
 }
 
 func jobFromImage(rawImage string, cfg testRunnerConfig, testNum int) (testJob, error) {
@@ -378,28 +289,11 @@ func jobFromImage(rawImage string, cfg testRunnerConfig, testNum int) (testJob, 
 }
 
 func normalizeImageAlias(image string) string {
-	if strings.HasPrefix(image, imagePerconaPrefix) {
-		version := strings.TrimPrefix(image, imagePerconaPrefix)
-		if isVersionInSeries(version, versionPercona80) {
-			return imagePerconaServerPrefix + version
-		}
-	}
-	return image
+	return testmatrix.NormalizeImageAlias(image)
 }
 
 func inferDBTypeAndDisplayImage(image string) (databaseType, string, error) {
-	switch {
-	case strings.HasPrefix(image, imageMySQLPrefix):
-		return dbMySQL, image, nil
-	case strings.HasPrefix(image, imagePerconaPrefix) || strings.HasPrefix(image, imagePerconaRepoPrefix) || strings.HasPrefix(image, imageDockerPerconaRepoPrefix):
-		return dbPercona, image, nil
-	case strings.HasPrefix(image, imageMariaDBPrefix):
-		return dbMariaDB, image, nil
-	case strings.HasPrefix(image, imageTiDBPrefix):
-		return dbTiDB, strings.TrimPrefix(image, imageTiDBPrefix), nil
-	default:
-		return "", "", fmt.Errorf("could not infer database type from image %q", image)
-	}
+	return testmatrix.InferDatabaseAndDisplayImage(image)
 }
 
 func newTestJob(dbType databaseType, image, dockerImage string, cfg testRunnerConfig, testNum int) testJob {
@@ -423,8 +317,8 @@ func isARMPlatform() bool {
 }
 
 func needsAMD64Platform(dbType databaseType, image string) bool {
-	return (dbType == dbMySQL && imageIsInSeries(image, imageMySQLPrefix, versionMySQL57)) ||
-		(dbType == dbPercona && imageIsInSeries(image, imagePerconaPrefix, versionPercona57))
+	return (dbType == dbMySQL && testmatrix.ImageIsInSeries(image, testmatrix.ImageMySQLPrefix, testmatrix.VersionMySQL57)) ||
+		(dbType == dbPercona && testmatrix.ImageIsInSeries(image, testmatrix.ImagePerconaPrefix, testmatrix.VersionPercona57))
 }
 
 func shouldDisableRyukForPodman() bool {
@@ -435,18 +329,7 @@ func shouldSkipForPodmanPercona57Emulation(dbType databaseType, image string) bo
 	return isARMPlatform() &&
 		strings.Contains(os.Getenv(envDockerHost), podmanSocketName) &&
 		dbType == dbPercona &&
-		imageIsInSeries(image, imagePerconaPrefix, versionPercona57)
-}
-
-func imageIsInSeries(image, prefix, series string) bool {
-	if !strings.HasPrefix(image, prefix) {
-		return false
-	}
-	return isVersionInSeries(strings.TrimPrefix(image, prefix), series)
-}
-
-func isVersionInSeries(version, series string) bool {
-	return version == series || strings.HasPrefix(version, series+".")
+		testmatrix.ImageIsInSeries(image, testmatrix.ImagePerconaPrefix, testmatrix.VersionPercona57)
 }
 
 func truthyEnv(key string) bool {
@@ -928,7 +811,7 @@ func (t *incrementalResultTable) append(result testResult) {
 
 	t.printHeaderLocked()
 	printResultTableRow([]string{
-		string(result.dbType),
+		result.dbType.Label(),
 		extractVersion(result.image),
 		resultStatus(result),
 		formatDuration(result.duration),

--- a/scripts/test-runner.go
+++ b/scripts/test-runner.go
@@ -33,7 +33,7 @@ const (
 
 const (
 	defaultTestPackage = "./mysql/..."
-	defaultTestTimeout = "15m"
+	defaultTestTimeout = "30m"
 	defaultTestPattern = runAllTestPattern
 	runAllTestPattern  = "."
 )

--- a/scripts/update-test-matrix.go
+++ b/scripts/update-test-matrix.go
@@ -69,6 +69,7 @@ func main() {
 	failOnWarning := flag.Bool("fail-on-warning", false, "exit non-zero when drift or EOL warnings are found")
 	failOnRed := flag.Bool("fail-on-red", false, "exit non-zero when any row has a red status")
 	githubActions := flag.Bool("github-actions", false, "emit GitHub Actions warning/error annotations")
+	summaryFile := flag.String("summary-file", "", "write the Markdown matrix policy summary to this file")
 	flag.Parse()
 
 	client := &http.Client{Timeout: 30 * time.Second}
@@ -97,7 +98,7 @@ func main() {
 	stopSpinner()
 	printResultsTable(results)
 	if *githubActions {
-		reportGitHubActionsStatus(results)
+		reportGitHubActionsStatus(results, *summaryFile)
 	}
 
 	if *write && len(replacements) > 0 {
@@ -282,9 +283,9 @@ func (severity resultSeverity) Circle() string {
 	}
 }
 
-func reportGitHubActionsStatus(results []matrixCheckResult) {
+func reportGitHubActionsStatus(results []matrixCheckResult, summaryFile string) {
 	severity := maxResultSeverity(results)
-	if err := writeGitHubStepSummary(results, severity); err != nil {
+	if err := writeGitHubSummaries(githubStepSummary(results, severity), summaryFile); err != nil {
 		fmt.Fprintf(os.Stderr, "::warning title=Matrix version policy summary::%s\n", githubActionsEscape(err.Error()))
 	}
 
@@ -300,19 +301,30 @@ func reportGitHubActionsStatus(results []matrixCheckResult) {
 	}
 }
 
-func writeGitHubStepSummary(results []matrixCheckResult, severity resultSeverity) error {
-	path := os.Getenv("GITHUB_STEP_SUMMARY")
-	if path == "" {
-		return nil
+func writeGitHubSummaries(summary, summaryFile string) error {
+	if path := os.Getenv("GITHUB_STEP_SUMMARY"); path != "" {
+		if err := appendFile(path, summary); err != nil {
+			return err
+		}
 	}
 
+	if summaryFile != "" && summaryFile != os.Getenv("GITHUB_STEP_SUMMARY") {
+		if err := os.WriteFile(summaryFile, []byte(summary), 0o644); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func appendFile(path, content string) error {
 	file, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
 	if err != nil {
 		return err
 	}
 	defer file.Close()
 
-	_, err = file.WriteString(githubStepSummary(results, severity))
+	_, err = file.WriteString(content)
 	return err
 }
 

--- a/scripts/update-test-matrix.go
+++ b/scripts/update-test-matrix.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"html"
 	"io"
 	"net/http"
 	"os"
@@ -11,17 +12,25 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
+	"github.com/jedib0t/go-pretty/v6/table"
 	"github.com/zph/terraform-provider-mysql/v3/internal/testmatrix"
 )
 
 const (
 	fileTestMatrix = "internal/testmatrix/matrix.go"
 
-	dockerHubTagURL = "https://registry.hub.docker.com/v2/repositories/%s/tags?page_size=100"
-	eolAPIURL       = "https://endoflife.date/api/%s.json"
+	dockerHubTagURL                 = "https://registry.hub.docker.com/v2/repositories/%s/tags?page_size=100"
+	eolAPIURL                       = "https://endoflife.date/api/%s.json"
+	mariadbMaintenancePolicySource  = "https://mariadb.org/about/"
+	tidbSelfManagedReleaseNotesURL  = "https://docs.pingcap.com/releases/tidb-self-managed.md"
+	tidbReleaseSupportPolicySource  = "https://www.pingcap.com/tidb-release-support-policy/"
+	tidbReleaseSupportPolicyProduct = "TiDB Community Edition"
 )
+
+var textCache = map[string]string{}
 
 type dockerHubTagsResponse struct {
 	Next    string `json:"next"`
@@ -34,54 +43,61 @@ type eolCycle struct {
 	Cycle  string          `json:"cycle"`
 	EOL    json.RawMessage `json:"eol"`
 	Latest string          `json:"latest"`
+	LTS    json.RawMessage `json:"lts"`
 }
+
+type matrixCheckResult struct {
+	Entry        testmatrix.Entry
+	Latest       string
+	EOL          string
+	Replacement  *versionReplacement
+	PatchWarning bool
+	EOLWarning   bool
+	NewerLine    bool
+}
+
+type resultSeverity int
+
+const (
+	severityGreen resultSeverity = iota
+	severityYellow
+	severityRed
+)
 
 func main() {
 	write := flag.Bool("write", false, "rewrite known matrix versions in repo files")
 	failOnWarning := flag.Bool("fail-on-warning", false, "exit non-zero when drift or EOL warnings are found")
+	failOnRed := flag.Bool("fail-on-red", false, "exit non-zero when any row has a red status")
+	githubActions := flag.Bool("github-actions", false, "emit GitHub Actions warning/error annotations")
 	flag.Parse()
 
 	client := &http.Client{Timeout: 30 * time.Second}
 	var replacements []versionReplacement
 	hadWarning := false
+	results := make([]matrixCheckResult, 0, len(testmatrix.All()))
+	stopSpinner := startSpinner("Checking matrix versions")
 
 	for _, entry := range testmatrix.All() {
-		latest, err := latestPatchTag(client, entry)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "WARN %s %s: latest patch lookup failed: %v\n", entry.Database, entry.Cycle, err)
+		result := checkMatrixEntry(client, entry)
+		results = append(results, result)
+		if result.HasWarning() {
 			hadWarning = true
-			continue
 		}
-		if latest != entry.Version {
-			fmt.Printf("UPDATE %s %s: %s -> %s\n", entry.Database, entry.Cycle, entry.Version, latest)
-			replacements = append(replacements, versionReplacement{Entry: entry, Old: entry.Version, New: latest})
+		if result.Replacement != nil {
+			replacements = append(replacements, *result.Replacement)
+		}
+	}
+	for _, result := range newerLineResults(client, testmatrix.All()) {
+		results = append(results, result)
+		if result.HasWarning() {
 			hadWarning = true
-		} else {
-			fmt.Printf("OK     %s %s: %s\n", entry.Database, entry.Cycle, entry.Version)
 		}
+	}
 
-		if entry.EOLProduct == "" {
-			fmt.Printf("WARN   %s %s: no EOL API configured; check vendor release policy manually\n", entry.Database, entry.Cycle)
-			hadWarning = true
-			continue
-		}
-
-		eol, err := eolForCycle(client, entry.EOLProduct, entry.EOLCycle)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "WARN %s %s: EOL lookup failed: %v\n", entry.Database, entry.Cycle, err)
-			hadWarning = true
-			continue
-		}
-		if eol != "" && eol != "false" && eol != "true" {
-			if eolDate, err := time.Parse(time.DateOnly, eol); err == nil && time.Now().After(eolDate) {
-				proxy := ""
-				if entry.EOLProxyFor != "" {
-					proxy = fmt.Sprintf(" using %s as proxy", entry.EOLProduct)
-				}
-				fmt.Printf("WARN   %s %s: EOL on %s%s\n", entry.Database, entry.Cycle, eol, proxy)
-				hadWarning = true
-			}
-		}
+	stopSpinner()
+	printResultsTable(results)
+	if *githubActions {
+		reportGitHubActionsStatus(results)
 	}
 
 	if *write && len(replacements) > 0 {
@@ -91,12 +107,446 @@ func main() {
 		}
 	}
 
+	if *failOnRed && maxResultSeverity(results) == severityRed {
+		os.Exit(2)
+	}
+
 	if hadWarning && *failOnWarning {
 		os.Exit(2)
 	}
 }
 
-func latestPatchTag(client *http.Client, entry testmatrix.Entry) (string, error) {
+func checkMatrixEntry(client *http.Client, entry testmatrix.Entry) matrixCheckResult {
+	result := matrixCheckResult{
+		Entry:  entry,
+		Latest: "-",
+		EOL:    "-",
+	}
+
+	warnPatch := func() {
+		result.PatchWarning = true
+	}
+	warnEOL := func() {
+		result.EOLWarning = true
+	}
+
+	latest, err := latestPatchVersion(client, entry)
+	if err != nil {
+		warnPatch()
+	} else {
+		result.Latest = latest
+		if latest != entry.Version {
+			warnPatch()
+			result.Replacement = &versionReplacement{Entry: entry, Old: entry.Version, New: latest}
+		}
+	}
+
+	if entry.Database != testmatrix.TiDB && entry.EOLProduct == "" {
+		result.EOL = "manual"
+		warnEOL()
+		return result
+	}
+
+	eol, err := eolForEntry(client, entry)
+	if err != nil {
+		warnEOL()
+		return result
+	}
+	result.EOL = displayEOL(eol)
+
+	switch {
+	case eol == "" || eol == "false":
+	case eol == "true":
+		warnEOL()
+	default:
+		eolDate, err := time.Parse(time.DateOnly, eol)
+		if err != nil {
+			warnEOL()
+			break
+		}
+		if time.Now().After(eolDate) {
+			warnEOL()
+		}
+	}
+
+	return result
+}
+
+func (result matrixCheckResult) HasWarning() bool {
+	return result.PatchWarning || result.EOLWarning || result.NewerLine
+}
+
+func displayEOL(eol string) string {
+	switch eol {
+	case "":
+		return "-"
+	case "false":
+		return "active"
+	default:
+		return eol
+	}
+}
+
+func printResultsTable(results []matrixCheckResult) {
+	sortMatrixCheckResults(results)
+
+	writer := table.NewWriter()
+	writer.SetStyle(table.StyleLight)
+	writer.AppendHeader(table.Row{"Status", "Database", "Cycle", "Current", "Latest", "EOL Date", "Notes (patch/EOL)"})
+	for _, result := range results {
+		writer.AppendRow(table.Row{
+			totalStatus(result),
+			result.Entry.Database.Label(),
+			result.Entry.Cycle,
+			result.Entry.Version,
+			result.Latest,
+			result.EOL,
+			resultNotes(result),
+		})
+	}
+	fmt.Println(writer.Render())
+}
+
+func sortMatrixCheckResults(results []matrixCheckResult) {
+	sort.SliceStable(results, func(i, j int) bool {
+		left := results[i]
+		right := results[j]
+
+		leftDB := left.Entry.Database.Label()
+		rightDB := right.Entry.Database.Label()
+		if leftDB != rightDB {
+			return leftDB < rightDB
+		}
+
+		cycleCompare := compareSemanticVersions(left.Entry.Cycle, right.Entry.Cycle)
+		if cycleCompare != 0 {
+			return cycleCompare < 0
+		}
+
+		versionCompare := compareSemanticVersions(left.Entry.Version, right.Entry.Version)
+		if versionCompare != 0 {
+			return versionCompare < 0
+		}
+
+		return left.Latest < right.Latest
+	})
+}
+
+func totalStatus(result matrixCheckResult) string {
+	return resultSeverityFor(result).Circle()
+}
+
+func statusCircle(ok bool) string {
+	if ok {
+		return "🟢"
+	}
+	return "🟡"
+}
+
+func resultNotes(result matrixCheckResult) string {
+	patch := statusCircle(!result.PatchWarning)
+	if result.NewerLine {
+		patch = "🔴"
+	}
+	return fmt.Sprintf("%s/%s", patch, statusCircle(!result.EOLWarning))
+}
+
+func resultSeverityFor(result matrixCheckResult) resultSeverity {
+	if result.NewerLine {
+		return severityRed
+	}
+	if result.HasWarning() {
+		return severityYellow
+	}
+	return severityGreen
+}
+
+func maxResultSeverity(results []matrixCheckResult) resultSeverity {
+	maxSeverity := severityGreen
+	for _, result := range results {
+		if severity := resultSeverityFor(result); severity > maxSeverity {
+			maxSeverity = severity
+		}
+	}
+	return maxSeverity
+}
+
+func (severity resultSeverity) Circle() string {
+	switch severity {
+	case severityRed:
+		return "🔴"
+	case severityYellow:
+		return "🟡"
+	default:
+		return "🟢"
+	}
+}
+
+func reportGitHubActionsStatus(results []matrixCheckResult) {
+	switch maxResultSeverity(results) {
+	case severityRed:
+		fmt.Fprintf(os.Stderr, "::error title=Matrix version policy::%s\n", githubActionsEscape(resultSummary(results, severityRed)))
+	case severityYellow:
+		fmt.Fprintf(os.Stderr, "::warning title=Matrix version policy::%s\n", githubActionsEscape(resultSummary(results, severityYellow)))
+	}
+}
+
+func resultSummary(results []matrixCheckResult, severity resultSeverity) string {
+	var summaries []string
+	for _, result := range results {
+		if resultSeverityFor(result) != severity {
+			continue
+		}
+		summaries = append(summaries, fmt.Sprintf("%s %s current=%s latest=%s eol=%s",
+			result.Entry.Database.Label(),
+			result.Entry.Cycle,
+			result.Entry.Version,
+			result.Latest,
+			result.EOL,
+		))
+	}
+
+	switch severity {
+	case severityRed:
+		return "Red matrix rows require action: " + strings.Join(summaries, "; ")
+	case severityYellow:
+		return "Yellow matrix rows should be reviewed: " + strings.Join(summaries, "; ")
+	default:
+		return "Matrix versions are current and supported"
+	}
+}
+
+func githubActionsEscape(message string) string {
+	message = strings.ReplaceAll(message, "%", "%25")
+	message = strings.ReplaceAll(message, "\r", "%0D")
+	message = strings.ReplaceAll(message, "\n", "%0A")
+	return message
+}
+
+func startSpinner(message string) func() {
+	if !stderrIsTerminal() {
+		return func() {}
+	}
+
+	done := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	go func() {
+		defer wg.Done()
+
+		frames := []string{"-", "\\", "|", "/"}
+		ticker := time.NewTicker(120 * time.Millisecond)
+		defer ticker.Stop()
+
+		for i := 0; ; i++ {
+			fmt.Fprintf(os.Stderr, "\r%s %s", frames[i%len(frames)], message)
+
+			select {
+			case <-done:
+				fmt.Fprint(os.Stderr, "\r\033[K")
+				return
+			case <-ticker.C:
+			}
+		}
+	}()
+
+	return func() {
+		close(done)
+		wg.Wait()
+	}
+}
+
+func stderrIsTerminal() bool {
+	info, err := os.Stderr.Stat()
+	return err == nil && (info.Mode()&os.ModeCharDevice) != 0
+}
+
+func latestPatchVersion(client *http.Client, entry testmatrix.Entry) (string, error) {
+	if entry.Database == testmatrix.TiDB {
+		return latestTiDBPatchVersion(client, entry)
+	}
+	return latestDockerHubPatchTag(client, entry)
+}
+
+func newerLineResults(client *http.Client, entries []testmatrix.Entry) []matrixCheckResult {
+	latestEntriesByDB := maxCycleEntries(entries)
+	results := []matrixCheckResult{}
+
+	for _, db := range []testmatrix.Database{testmatrix.MySQL, testmatrix.Percona, testmatrix.MariaDB, testmatrix.TiDB} {
+		entry, ok := latestEntriesByDB[db]
+		if !ok {
+			continue
+		}
+
+		versions, err := newerActiveVersions(client, entry)
+		if err != nil {
+			results = append(results, matrixCheckResult{
+				Entry: testmatrix.Entry{
+					Database: entry.Database,
+					Cycle:    "newer",
+					Version:  "lookup failed",
+				},
+				Latest:       "-",
+				EOL:          "-",
+				PatchWarning: true,
+			})
+			continue
+		}
+
+		cycles := sortedVersionCycles(versions)
+		for _, cycle := range cycles {
+			if compareVersions(cycle, entry.Cycle) <= 0 {
+				continue
+			}
+
+			eol, active := matrixCandidateEOLForNewerCycle(client, entry, cycle)
+			if !active {
+				continue
+			}
+
+			results = append(results, matrixCheckResult{
+				Entry: testmatrix.Entry{
+					Database: entry.Database,
+					Cycle:    cycle,
+					Version:  "-",
+				},
+				Latest:    versions[cycle],
+				EOL:       displayEOL(eol),
+				NewerLine: true,
+			})
+		}
+	}
+
+	return results
+}
+
+func maxCycleEntries(entries []testmatrix.Entry) map[testmatrix.Database]testmatrix.Entry {
+	latest := make(map[testmatrix.Database]testmatrix.Entry)
+	for _, entry := range entries {
+		current, ok := latest[entry.Database]
+		if !ok || compareVersions(entry.Cycle, current.Cycle) > 0 {
+			latest[entry.Database] = entry
+		}
+	}
+	return latest
+}
+
+func newerActiveVersions(client *http.Client, entry testmatrix.Entry) (map[string]string, error) {
+	if entry.Database == testmatrix.TiDB {
+		return tidbReleasedVersionsByCycle(client)
+	}
+	return dockerHubVersionsByCycle(client, entry)
+}
+
+func sortedVersionCycles(versions map[string]string) []string {
+	cycles := make([]string, 0, len(versions))
+	for cycle := range versions {
+		cycles = append(cycles, cycle)
+	}
+	sort.Slice(cycles, func(i, j int) bool {
+		return compareVersions(cycles[i], cycles[j]) < 0
+	})
+	return cycles
+}
+
+func matrixCandidateEOLForNewerCycle(client *http.Client, entry testmatrix.Entry, cycle string) (string, bool) {
+	eol, err := matrixCandidateEOL(client, entry, cycle)
+	if err != nil {
+		return "", false
+	}
+	return eol, eolIsActive(eol)
+}
+
+func matrixCandidateEOL(client *http.Client, entry testmatrix.Entry, cycle string) (string, error) {
+	switch entry.Database {
+	case testmatrix.MariaDB:
+		return mariadbCommunityEOLDate(client, cycle)
+	case testmatrix.MySQL, testmatrix.Percona:
+		candidate, err := eolCycleIsLTS(client, entry.EOLProduct, cycle)
+		if err != nil {
+			return "", err
+		}
+		if !candidate {
+			return "", fmt.Errorf("cycle %s is not an LTS cycle for %s", cycle, entry.EOLProduct)
+		}
+	}
+
+	eolEntry := entry
+	eolEntry.Cycle = cycle
+	eolEntry.EOLCycle = cycle
+
+	return eolForEntry(client, eolEntry)
+}
+
+func eolIsActive(eol string) bool {
+	if eol == "" || eol == "false" {
+		return true
+	}
+	if eol == "true" {
+		return false
+	}
+
+	eolDate, err := time.Parse(time.DateOnly, eol)
+	if err != nil {
+		return false
+	}
+	return !time.Now().After(eolDate)
+}
+
+func latestTiDBPatchVersion(client *http.Client, entry testmatrix.Entry) (string, error) {
+	body, err := getCachedText(client, tidbSelfManagedReleaseNotesURL)
+	if err != nil {
+		return "", err
+	}
+
+	re := regexp.MustCompile(`\b` + regexp.QuoteMeta(entry.Cycle) + `\.\d+\b`)
+	rawMatches := re.FindAllString(body, -1)
+	if len(rawMatches) == 0 {
+		return "", fmt.Errorf("no TiDB release notes match cycle %s in %s", entry.Cycle, tidbSelfManagedReleaseNotesURL)
+	}
+
+	seen := make(map[string]struct{}, len(rawMatches))
+	matches := make([]string, 0, len(rawMatches))
+	for _, match := range rawMatches {
+		if _, ok := seen[match]; ok {
+			continue
+		}
+		seen[match] = struct{}{}
+		matches = append(matches, match)
+	}
+
+	sort.Slice(matches, func(i, j int) bool {
+		return compareVersions(matches[i], matches[j]) > 0
+	})
+	return matches[0], nil
+}
+
+func tidbReleasedVersionsByCycle(client *http.Client) (map[string]string, error) {
+	body, err := getCachedText(client, tidbSelfManagedReleaseNotesURL)
+	if err != nil {
+		return nil, err
+	}
+
+	versions := map[string]string{}
+	re := regexp.MustCompile(`\b\d+\.\d+\.\d+(?:-[A-Za-z0-9.]+)?\b`)
+	for _, match := range re.FindAllString(body, -1) {
+		if strings.Contains(match, "-") {
+			continue
+		}
+		cycle := versionCycle(match)
+		if cycle == "" {
+			continue
+		}
+		if current, ok := versions[cycle]; !ok || compareVersions(match, current) > 0 {
+			versions[cycle] = match
+		}
+	}
+
+	return versions, nil
+}
+
+func latestDockerHubPatchTag(client *http.Client, entry testmatrix.Entry) (string, error) {
 	tagPattern := "^" + regexp.QuoteMeta(entry.TagPrefix+entry.Cycle) + `\.\d+`
 	if entry.BuildSuffix {
 		tagPattern += `(?:-\d+)?`
@@ -129,25 +579,160 @@ func latestPatchTag(client *http.Client, entry testmatrix.Entry) (string, error)
 	return matches[0], nil
 }
 
+func dockerHubVersionsByCycle(client *http.Client, entry testmatrix.Entry) (map[string]string, error) {
+	versionPattern := `\d+\.\d+\.\d+`
+	if entry.BuildSuffix {
+		versionPattern += `(?:-\d+)?`
+	}
+	re := regexp.MustCompile("^" + regexp.QuoteMeta(entry.TagPrefix) + "(" + versionPattern + ")$")
+	versions := map[string]string{}
+	url := fmt.Sprintf(dockerHubTagURL, entry.DockerRepo)
+
+	for url != "" {
+		var payload dockerHubTagsResponse
+		if err := getJSON(client, url, &payload); err != nil {
+			return nil, err
+		}
+		for _, tag := range payload.Results {
+			matches := re.FindStringSubmatch(tag.Name)
+			if len(matches) != 2 {
+				continue
+			}
+
+			version := strings.TrimPrefix(matches[1], entry.TagPrefix)
+			cycle := versionCycle(version)
+			if cycle == "" {
+				continue
+			}
+			if current, ok := versions[cycle]; !ok || compareVersions(version, current) > 0 {
+				versions[cycle] = version
+			}
+		}
+		url = payload.Next
+	}
+
+	return versions, nil
+}
+
+func versionCycle(version string) string {
+	fields := regexp.MustCompile(`\d+`).FindAllString(version, -1)
+	if len(fields) < 2 {
+		return ""
+	}
+	return fields[0] + "." + fields[1]
+}
+
+func eolForEntry(client *http.Client, entry testmatrix.Entry) (string, error) {
+	if entry.Database == testmatrix.TiDB {
+		return tidbCommunityEOLDate(client, entry.Cycle)
+	}
+	return eolForCycle(client, entry.EOLProduct, entry.EOLCycle)
+}
+
+func tidbCommunityEOLDate(client *http.Client, cycle string) (string, error) {
+	body, err := getCachedText(client, tidbReleaseSupportPolicySource)
+	if err != nil {
+		return "", err
+	}
+
+	text := htmlText(body)
+	re := regexp.MustCompile(`v\s*` + cycleRegex(cycle) + `\s+Community\s+Edition\s+\d{1,2}/\d{1,2}/\d{4}\s+\d{1,2}/\d{1,2}/\d{4}\s+(\d{1,2}/\d{1,2}/\d{4})`)
+	matches := re.FindStringSubmatch(text)
+	if len(matches) != 2 {
+		return "", fmt.Errorf("no %s EOL date configured for cycle %s from %s", tidbReleaseSupportPolicyProduct, cycle, tidbReleaseSupportPolicySource)
+	}
+
+	eolDate, err := time.Parse("1/2/2006", matches[1])
+	if err != nil {
+		return "", fmt.Errorf("invalid %s EOL date %q for cycle %s from %s: %w", tidbReleaseSupportPolicyProduct, matches[1], cycle, tidbReleaseSupportPolicySource, err)
+	}
+	return eolDate.Format(time.DateOnly), nil
+}
+
+func mariadbCommunityEOLDate(client *http.Client, cycle string) (string, error) {
+	body, err := getCachedText(client, mariadbMaintenancePolicySource)
+	if err != nil {
+		return "", err
+	}
+
+	text := htmlText(body)
+	datePattern := `(?:\d{1,2}\s+[A-Za-z]{3}\s+\d{4}|TBC)`
+	re := regexp.MustCompile(`\b` + cycleRegex(cycle) + `\s+` + datePattern + `\s+(` + datePattern + `)\s+` + datePattern + `\s+` + datePattern + `\b`)
+	matches := re.FindStringSubmatch(text)
+	if len(matches) != 2 {
+		return "", fmt.Errorf("no MariaDB Community EOL date configured for cycle %s from %s", cycle, mariadbMaintenancePolicySource)
+	}
+	if matches[1] == "TBC" {
+		return "", fmt.Errorf("MariaDB Community EOL date is TBC for cycle %s from %s", cycle, mariadbMaintenancePolicySource)
+	}
+
+	eolDate, err := time.Parse("2 Jan 2006", matches[1])
+	if err != nil {
+		return "", fmt.Errorf("invalid MariaDB Community EOL date %q for cycle %s from %s: %w", matches[1], cycle, mariadbMaintenancePolicySource, err)
+	}
+	return eolDate.Format(time.DateOnly), nil
+}
+
+func cycleRegex(cycle string) string {
+	parts := strings.Split(cycle, ".")
+	quoted := make([]string, 0, len(parts))
+	for _, part := range parts {
+		quoted = append(quoted, regexp.QuoteMeta(part))
+	}
+	return strings.Join(quoted, `\s*\.\s*`)
+}
+
 func eolForCycle(client *http.Client, product, cycle string) (string, error) {
+	c, err := eolCycleFor(client, product, cycle)
+	if err != nil {
+		return "", err
+	}
+	return rawStringOrBool(c.EOL), nil
+}
+
+func eolCycleIsLTS(client *http.Client, product, cycle string) (bool, error) {
+	c, err := eolCycleFor(client, product, cycle)
+	if err != nil {
+		return false, err
+	}
+	return rawMessageIsTruthy(c.LTS), nil
+}
+
+func eolCycleFor(client *http.Client, product, cycle string) (eolCycle, error) {
 	var cycles []eolCycle
 	if err := getJSON(client, fmt.Sprintf(eolAPIURL, product), &cycles); err != nil {
-		return "", err
+		return eolCycle{}, err
 	}
 	for _, c := range cycles {
 		if c.Cycle == cycle {
-			var asString string
-			if err := json.Unmarshal(c.EOL, &asString); err == nil {
-				return asString, nil
-			}
-			var asBool bool
-			if err := json.Unmarshal(c.EOL, &asBool); err == nil {
-				return fmt.Sprintf("%t", asBool), nil
-			}
-			return "", nil
+			return c, nil
 		}
 	}
-	return "", fmt.Errorf("cycle %s not found for %s", cycle, product)
+	return eolCycle{}, fmt.Errorf("cycle %s not found for %s", cycle, product)
+}
+
+func rawStringOrBool(raw json.RawMessage) string {
+	var asString string
+	if err := json.Unmarshal(raw, &asString); err == nil {
+		return asString
+	}
+	var asBool bool
+	if err := json.Unmarshal(raw, &asBool); err == nil {
+		return fmt.Sprintf("%t", asBool)
+	}
+	return ""
+}
+
+func rawMessageIsTruthy(raw json.RawMessage) bool {
+	if len(raw) == 0 {
+		return false
+	}
+	switch rawStringOrBool(raw) {
+	case "", "false":
+		return false
+	default:
+		return true
+	}
 }
 
 func getJSON(client *http.Client, url string, out interface{}) error {
@@ -160,6 +745,40 @@ func getJSON(client *http.Client, url string, out interface{}) error {
 		return fmt.Errorf("%s returned %s", url, resp.Status)
 	}
 	return json.NewDecoder(io.LimitReader(resp.Body, 16<<20)).Decode(out)
+}
+
+func getCachedText(client *http.Client, url string) (string, error) {
+	if cached, ok := textCache[url]; ok {
+		return cached, nil
+	}
+	body, err := getText(client, url)
+	if err != nil {
+		return "", err
+	}
+	textCache[url] = body
+	return body, nil
+}
+
+func getText(client *http.Client, url string) (string, error) {
+	resp, err := client.Get(url)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return "", fmt.Errorf("%s returned %s", url, resp.Status)
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 16<<20))
+	if err != nil {
+		return "", err
+	}
+	return string(body), nil
+}
+
+func htmlText(body string) string {
+	withoutTags := regexp.MustCompile(`<[^>]+>`).ReplaceAllString(body, " ")
+	unescaped := html.UnescapeString(withoutTags)
+	return strings.Join(strings.Fields(unescaped), " ")
 }
 
 type versionReplacement struct {
@@ -213,8 +832,21 @@ func replaceOnce(file, content, oldToken, newToken string) (string, error) {
 }
 
 func compareVersions(a, b string) int {
+	return compareSemanticVersions(a, b)
+}
+
+func compareSemanticVersions(a, b string) int {
 	ap := versionParts(a)
 	bp := versionParts(b)
+	if len(ap) == 0 && len(bp) == 0 {
+		return strings.Compare(a, b)
+	}
+	if len(ap) == 0 {
+		return 1
+	}
+	if len(bp) == 0 {
+		return -1
+	}
 	for i := 0; i < len(ap) || i < len(bp); i++ {
 		av, bv := 0, 0
 		if i < len(ap) {

--- a/scripts/update-test-matrix.go
+++ b/scripts/update-test-matrix.go
@@ -12,37 +12,16 @@ import (
 	"strconv"
 	"strings"
 	"time"
-)
 
-type matrixDatabase string
-
-const (
-	matrixMySQL   matrixDatabase = "mysql"
-	matrixPercona matrixDatabase = "percona"
-	matrixMariaDB matrixDatabase = "mariadb"
-	matrixTiDB    matrixDatabase = "tidb"
+	"github.com/zph/terraform-provider-mysql/v3/internal/testmatrix"
 )
 
 const (
-	fileTestRunner     = "scripts/test-runner.go"
-	fileMatrixUpdater  = "scripts/update-test-matrix.go"
-	fileGitHubWorkflow = ".github/workflows/main.yml"
+	fileTestMatrix = "internal/testmatrix/matrix.go"
 
 	dockerHubTagURL = "https://registry.hub.docker.com/v2/repositories/%s/tags?page_size=100"
 	eolAPIURL       = "https://endoflife.date/api/%s.json"
 )
-
-type matrixEntry struct {
-	Name        matrixDatabase
-	Cycle       string
-	Current     string
-	DockerRepo  string
-	TagPrefix   string
-	BuildSuffix bool
-	EOLProduct  string
-	EOLCycle    string
-	EOLProxyFor string
-}
 
 type dockerHubTagsResponse struct {
 	Next    string `json:"next"`
@@ -57,22 +36,6 @@ type eolCycle struct {
 	Latest string          `json:"latest"`
 }
 
-var matrixEntries = []matrixEntry{
-	{Name: matrixMySQL, Cycle: "5.7", Current: "5.7", DockerRepo: "library/mysql", EOLProduct: "mysql", EOLCycle: "5.7"},
-	{Name: matrixMySQL, Cycle: "8.0", Current: "8.0", DockerRepo: "library/mysql", EOLProduct: "mysql", EOLCycle: "8.0"},
-	{Name: matrixPercona, Cycle: "5.7", Current: "5.7", DockerRepo: "library/percona", BuildSuffix: true, EOLProduct: "mysql", EOLCycle: "5.7", EOLProxyFor: "Percona Server"},
-	{Name: matrixPercona, Cycle: "8.0", Current: "8.0", DockerRepo: "percona/percona-server", BuildSuffix: true, EOLProduct: "mysql", EOLCycle: "8.0", EOLProxyFor: "Percona Server"},
-	{Name: matrixMariaDB, Cycle: "10.3", Current: "10.3", DockerRepo: "library/mariadb", EOLProduct: "mariadb", EOLCycle: "10.3"},
-	{Name: matrixMariaDB, Cycle: "10.8", Current: "10.8", DockerRepo: "library/mariadb", EOLProduct: "mariadb", EOLCycle: "10.8"},
-	{Name: matrixMariaDB, Cycle: "10.10", Current: "10.10", DockerRepo: "library/mariadb", EOLProduct: "mariadb", EOLCycle: "10.10"},
-	{Name: matrixTiDB, Cycle: "6.1", Current: "6.1.7", DockerRepo: "pingcap/tidb", TagPrefix: "v"},
-	{Name: matrixTiDB, Cycle: "6.5", Current: "6.5.12", DockerRepo: "pingcap/tidb", TagPrefix: "v"},
-	{Name: matrixTiDB, Cycle: "7.1", Current: "7.1.6", DockerRepo: "pingcap/tidb", TagPrefix: "v"},
-	{Name: matrixTiDB, Cycle: "7.5", Current: "7.5.7", DockerRepo: "pingcap/tidb", TagPrefix: "v"},
-	{Name: matrixTiDB, Cycle: "8.1", Current: "8.1.2", DockerRepo: "pingcap/tidb", TagPrefix: "v"},
-	{Name: matrixTiDB, Cycle: "8.5", Current: "8.5.5", DockerRepo: "pingcap/tidb", TagPrefix: "v"},
-}
-
 func main() {
 	write := flag.Bool("write", false, "rewrite known matrix versions in repo files")
 	failOnWarning := flag.Bool("fail-on-warning", false, "exit non-zero when drift or EOL warnings are found")
@@ -82,30 +45,30 @@ func main() {
 	var replacements []versionReplacement
 	hadWarning := false
 
-	for _, entry := range matrixEntries {
+	for _, entry := range testmatrix.All() {
 		latest, err := latestPatchTag(client, entry)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "WARN %s %s: latest patch lookup failed: %v\n", entry.Name, entry.Cycle, err)
+			fmt.Fprintf(os.Stderr, "WARN %s %s: latest patch lookup failed: %v\n", entry.Database, entry.Cycle, err)
 			hadWarning = true
 			continue
 		}
-		if latest != entry.Current {
-			fmt.Printf("UPDATE %s %s: %s -> %s\n", entry.Name, entry.Cycle, entry.Current, latest)
-			replacements = append(replacements, versionReplacement{Entry: entry, Old: entry.Current, New: latest})
+		if latest != entry.Version {
+			fmt.Printf("UPDATE %s %s: %s -> %s\n", entry.Database, entry.Cycle, entry.Version, latest)
+			replacements = append(replacements, versionReplacement{Entry: entry, Old: entry.Version, New: latest})
 			hadWarning = true
 		} else {
-			fmt.Printf("OK     %s %s: %s\n", entry.Name, entry.Cycle, entry.Current)
+			fmt.Printf("OK     %s %s: %s\n", entry.Database, entry.Cycle, entry.Version)
 		}
 
 		if entry.EOLProduct == "" {
-			fmt.Printf("WARN   %s %s: no EOL API configured; check vendor release policy manually\n", entry.Name, entry.Cycle)
+			fmt.Printf("WARN   %s %s: no EOL API configured; check vendor release policy manually\n", entry.Database, entry.Cycle)
 			hadWarning = true
 			continue
 		}
 
 		eol, err := eolForCycle(client, entry.EOLProduct, entry.EOLCycle)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "WARN %s %s: EOL lookup failed: %v\n", entry.Name, entry.Cycle, err)
+			fmt.Fprintf(os.Stderr, "WARN %s %s: EOL lookup failed: %v\n", entry.Database, entry.Cycle, err)
 			hadWarning = true
 			continue
 		}
@@ -115,7 +78,7 @@ func main() {
 				if entry.EOLProxyFor != "" {
 					proxy = fmt.Sprintf(" using %s as proxy", entry.EOLProduct)
 				}
-				fmt.Printf("WARN   %s %s: EOL on %s%s\n", entry.Name, entry.Cycle, eol, proxy)
+				fmt.Printf("WARN   %s %s: EOL on %s%s\n", entry.Database, entry.Cycle, eol, proxy)
 				hadWarning = true
 			}
 		}
@@ -133,7 +96,7 @@ func main() {
 	}
 }
 
-func latestPatchTag(client *http.Client, entry matrixEntry) (string, error) {
+func latestPatchTag(client *http.Client, entry testmatrix.Entry) (string, error) {
 	tagPattern := "^" + regexp.QuoteMeta(entry.TagPrefix+entry.Cycle) + `\.\d+`
 	if entry.BuildSuffix {
 		tagPattern += `(?:-\d+)?`
@@ -200,52 +163,22 @@ func getJSON(client *http.Client, url string, out interface{}) error {
 }
 
 type versionReplacement struct {
-	Entry matrixEntry
+	Entry testmatrix.Entry
 	Old   string
 	New   string
 }
 
 func applyReplacements(replacements []versionReplacement) error {
-	if err := rewriteFile(fileTestRunner, func(content string) (string, error) {
+	return rewriteFile(fileTestMatrix, func(content string) (string, error) {
 		for _, replacement := range replacements {
 			var err error
-			content, err = replaceTestRunnerVersion(content, replacement)
+			content, err = replaceMatrixVersion(content, replacement)
 			if err != nil {
 				return "", err
 			}
 		}
 		return content, nil
-	}); err != nil {
-		return err
-	}
-
-	if err := rewriteFile(fileMatrixUpdater, func(content string) (string, error) {
-		for _, replacement := range replacements {
-			var err error
-			content, err = replaceUpdaterCurrentVersion(content, replacement)
-			if err != nil {
-				return "", err
-			}
-		}
-		return content, nil
-	}); err != nil {
-		return err
-	}
-
-	if err := rewriteFile(fileGitHubWorkflow, func(content string) (string, error) {
-		for _, replacement := range replacements {
-			var err error
-			content, err = replaceWorkflowVersion(content, replacement)
-			if err != nil {
-				return "", err
-			}
-		}
-		return syncTiDBWorkflowComment(content), nil
-	}); err != nil {
-		return err
-	}
-
-	return nil
+	})
 }
 
 func rewriteFile(file string, mutate func(string) (string, error)) error {
@@ -265,37 +198,10 @@ func rewriteFile(file string, mutate func(string) (string, error)) error {
 	return os.WriteFile(file, []byte(updated), 0o644)
 }
 
-func replaceTestRunnerVersion(content string, replacement versionReplacement) (string, error) {
-	return replaceOnce(
-		fileTestRunner,
-		content,
-		replacement.Entry.testRunnerToken(replacement.Old),
-		replacement.Entry.testRunnerToken(replacement.New),
-	)
-}
-
-func replaceUpdaterCurrentVersion(content string, replacement versionReplacement) (string, error) {
-	oldToken := fmt.Sprintf("Name: %s, Cycle: %q, Current: %q", replacement.Entry.constName(), replacement.Entry.Cycle, replacement.Old)
-	newToken := fmt.Sprintf("Name: %s, Cycle: %q, Current: %q", replacement.Entry.constName(), replacement.Entry.Cycle, replacement.New)
-	return replaceOnce(fileMatrixUpdater, content, oldToken, newToken)
-}
-
-func replaceWorkflowVersion(content string, replacement versionReplacement) (string, error) {
-	oldBlock := fmt.Sprintf("db_version: %q\n          make_target: %q", replacement.Old, replacement.Entry.makeTarget(replacement.Old))
-	newBlock := fmt.Sprintf("db_version: %q\n          make_target: %q", replacement.New, replacement.Entry.makeTarget(replacement.New))
-
-	next, err := replaceOnce(fileGitHubWorkflow, content, oldBlock, newBlock)
-	if err != nil {
-		return "", err
-	}
-
-	if replacement.Entry.Name == matrixTiDB {
-		next, err = replaceTiDBVersionsEnv(next, replacement.Old, replacement.New)
-		if err != nil {
-			return "", err
-		}
-	}
-	return next, nil
+func replaceMatrixVersion(content string, replacement versionReplacement) (string, error) {
+	oldToken := fmt.Sprintf("Database: %s, Cycle: %q, Version: %q", replacement.Entry.Database.ConstName(), replacement.Entry.Cycle, replacement.Old)
+	newToken := fmt.Sprintf("Database: %s, Cycle: %q, Version: %q", replacement.Entry.Database.ConstName(), replacement.Entry.Cycle, replacement.New)
+	return replaceOnce(fileTestMatrix, content, oldToken, newToken)
 }
 
 func replaceOnce(file, content, oldToken, newToken string) (string, error) {
@@ -304,82 +210,6 @@ func replaceOnce(file, content, oldToken, newToken string) (string, error) {
 		return "", fmt.Errorf("could not find %q in %s", oldToken, file)
 	}
 	return next, nil
-}
-
-func replaceTiDBVersionsEnv(content, oldVersion, newVersion string) (string, error) {
-	re := regexp.MustCompile(`TIDB_VERSIONS: "([^"]*)"`)
-	matches := re.FindStringSubmatchIndex(content)
-	if matches == nil {
-		return "", fmt.Errorf("could not find TIDB_VERSIONS in %s", fileGitHubWorkflow)
-	}
-
-	versions := strings.Fields(content[matches[2]:matches[3]])
-	replaced := false
-	for i, version := range versions {
-		if version == oldVersion {
-			versions[i] = newVersion
-			replaced = true
-		}
-	}
-	if !replaced {
-		return "", fmt.Errorf("could not find TiDB version %q in TIDB_VERSIONS", oldVersion)
-	}
-
-	newLine := `TIDB_VERSIONS: "` + strings.Join(versions, " ") + `"`
-	return content[:matches[0]] + newLine + content[matches[1]:], nil
-}
-
-func syncTiDBWorkflowComment(content string) string {
-	envRe := regexp.MustCompile(`TIDB_VERSIONS: "([^"]*)"`)
-	env := envRe.FindStringSubmatch(content)
-	if len(env) != 2 {
-		return content
-	}
-
-	commentRe := regexp.MustCompile(`# TiDB versions - must match env\.TIDB_VERSIONS: .*`)
-	return commentRe.ReplaceAllString(content, "# TiDB versions - must match env.TIDB_VERSIONS: "+env[1])
-}
-
-func (entry matrixEntry) testRunnerToken(version string) string {
-	if entry.Name == matrixTiDB {
-		return strconv.Quote(version)
-	}
-	return strconv.Quote(entry.dockerImage(version))
-}
-
-func (entry matrixEntry) dockerImage(version string) string {
-	switch entry.Name {
-	case matrixMySQL:
-		return "mysql:" + version
-	case matrixPercona:
-		if strings.HasPrefix(version, "8.0") {
-			return "percona/percona-server:" + version
-		}
-		return "percona:" + version
-	case matrixMariaDB:
-		return "mariadb:" + version
-	default:
-		return string(entry.Name) + ":" + version
-	}
-}
-
-func (entry matrixEntry) makeTarget(version string) string {
-	return fmt.Sprintf("test-%s-%s", entry.Name, version)
-}
-
-func (entry matrixEntry) constName() string {
-	switch entry.Name {
-	case matrixMySQL:
-		return "matrixMySQL"
-	case matrixPercona:
-		return "matrixPercona"
-	case matrixMariaDB:
-		return "matrixMariaDB"
-	case matrixTiDB:
-		return "matrixTiDB"
-	default:
-		return string(entry.Name)
-	}
 }
 
 func compareVersions(a, b string) int {

--- a/scripts/update-test-matrix.go
+++ b/scripts/update-test-matrix.go
@@ -53,6 +53,7 @@ type matrixCheckResult struct {
 	Replacement  *versionReplacement
 	PatchWarning bool
 	EOLWarning   bool
+	EOLCritical  bool
 	NewerLine    bool
 }
 
@@ -165,8 +166,12 @@ func checkMatrixEntry(client *http.Client, entry testmatrix.Entry) matrixCheckRe
 			warnEOL()
 			break
 		}
-		if time.Now().After(eolDate) {
+		now := time.Now()
+		if now.After(eolDate) {
 			warnEOL()
+			if eolIsOlderThanPolicy(eolDate, now) {
+				result.EOLCritical = true
+			}
 		}
 	}
 
@@ -174,7 +179,7 @@ func checkMatrixEntry(client *http.Client, entry testmatrix.Entry) matrixCheckRe
 }
 
 func (result matrixCheckResult) HasWarning() bool {
-	return result.PatchWarning || result.EOLWarning || result.NewerLine
+	return result.PatchWarning || result.EOLWarning || result.EOLCritical || result.NewerLine
 }
 
 func displayEOL(eol string) string {
@@ -193,7 +198,7 @@ func printResultsTable(results []matrixCheckResult) {
 
 	writer := table.NewWriter()
 	writer.SetStyle(table.StyleLight)
-	writer.AppendHeader(table.Row{"Status", "Database", "Cycle", "Current", "Latest", "EOL Date", "Notes (patch/EOL)"})
+	writer.AppendHeader(table.Row{"Status", "Database", "Cycle", "Current", "Latest", "EOL Date", "Notes (present/eol)"})
 	for _, result := range results {
 		writer.AppendRow(table.Row{
 			totalStatus(result),
@@ -249,11 +254,16 @@ func resultNotes(result matrixCheckResult) string {
 	if result.NewerLine {
 		patch = "🔴"
 	}
-	return fmt.Sprintf("%s/%s", patch, statusCircle(!result.EOLWarning))
+
+	eol := statusCircle(!result.EOLWarning)
+	if result.EOLCritical {
+		eol = "🔴"
+	}
+	return fmt.Sprintf("%s/%s", patch, eol)
 }
 
 func resultSeverityFor(result matrixCheckResult) resultSeverity {
-	if result.NewerLine {
+	if result.NewerLine || result.EOLCritical {
 		return severityRed
 	}
 	if result.HasWarning() {
@@ -281,6 +291,10 @@ func (severity resultSeverity) Circle() string {
 	default:
 		return "🟢"
 	}
+}
+
+func eolIsOlderThanPolicy(eolDate, now time.Time) bool {
+	return now.After(eolDate.AddDate(2, 0, 0))
 }
 
 func reportGitHubActionsStatus(results []matrixCheckResult, summaryFile string) {

--- a/scripts/update-test-matrix.go
+++ b/scripts/update-test-matrix.go
@@ -283,12 +283,121 @@ func (severity resultSeverity) Circle() string {
 }
 
 func reportGitHubActionsStatus(results []matrixCheckResult) {
-	switch maxResultSeverity(results) {
-	case severityRed:
-		fmt.Fprintf(os.Stderr, "::error title=Matrix version policy::%s\n", githubActionsEscape(resultSummary(results, severityRed)))
-	case severityYellow:
-		fmt.Fprintf(os.Stderr, "::warning title=Matrix version policy::%s\n", githubActionsEscape(resultSummary(results, severityYellow)))
+	severity := maxResultSeverity(results)
+	if err := writeGitHubStepSummary(results, severity); err != nil {
+		fmt.Fprintf(os.Stderr, "::warning title=Matrix version policy summary::%s\n", githubActionsEscape(err.Error()))
 	}
+
+	switch severity {
+	case severityRed:
+		for _, result := range resultsWithSeverity(results, severityRed) {
+			emitGitHubActionsAnnotation("error", result)
+		}
+	case severityYellow:
+		for _, result := range resultsWithSeverity(results, severityYellow) {
+			emitGitHubActionsAnnotation("warning", result)
+		}
+	}
+}
+
+func writeGitHubStepSummary(results []matrixCheckResult, severity resultSeverity) error {
+	path := os.Getenv("GITHUB_STEP_SUMMARY")
+	if path == "" {
+		return nil
+	}
+
+	file, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	_, err = file.WriteString(githubStepSummary(results, severity))
+	return err
+}
+
+func githubStepSummary(results []matrixCheckResult, severity resultSeverity) string {
+	var builder strings.Builder
+	builder.WriteString("## Matrix Version Policy\n\n")
+
+	switch severity {
+	case severityRed:
+		builder.WriteString("**Failing:** at least one active supported database line is missing from the test matrix.\n\n")
+	case severityYellow:
+		builder.WriteString("**Warning:** matrix entries need review, but no active supported line is missing.\n\n")
+	default:
+		builder.WriteString("All matrix versions are current and supported.\n\n")
+	}
+
+	nonGreen := nonGreenResults(results)
+	if len(nonGreen) == 0 {
+		return builder.String()
+	}
+
+	builder.WriteString("| Status | Database | Cycle | Current | Latest | EOL Date | Notes |\n")
+	builder.WriteString("| --- | --- | --- | --- | --- | --- | --- |\n")
+	for _, result := range nonGreen {
+		builder.WriteString(fmt.Sprintf("| %s | %s | %s | %s | %s | %s | %s |\n",
+			resultSeverityFor(result).Circle(),
+			markdownCell(result.Entry.Database.Label()),
+			markdownCell(result.Entry.Cycle),
+			markdownCell(result.Entry.Version),
+			markdownCell(result.Latest),
+			markdownCell(result.EOL),
+			markdownCell(resultNotes(result)),
+		))
+	}
+	builder.WriteString("\n")
+	return builder.String()
+}
+
+func nonGreenResults(results []matrixCheckResult) []matrixCheckResult {
+	filtered := make([]matrixCheckResult, 0, len(results))
+	for _, result := range results {
+		if resultSeverityFor(result) == severityGreen {
+			continue
+		}
+		filtered = append(filtered, result)
+	}
+	return filtered
+}
+
+func resultsWithSeverity(results []matrixCheckResult, severity resultSeverity) []matrixCheckResult {
+	filtered := make([]matrixCheckResult, 0, len(results))
+	for _, result := range results {
+		if resultSeverityFor(result) == severity {
+			filtered = append(filtered, result)
+		}
+	}
+	return filtered
+}
+
+func emitGitHubActionsAnnotation(kind string, result matrixCheckResult) {
+	fmt.Fprintf(os.Stderr, "::%s file=%s,title=%s::%s\n",
+		kind,
+		githubActionsPropertyEscape(fileTestMatrix),
+		githubActionsPropertyEscape(annotationTitle(kind, result)),
+		githubActionsEscape(annotationMessage(result)),
+	)
+}
+
+func annotationTitle(kind string, result matrixCheckResult) string {
+	switch kind {
+	case "error":
+		return fmt.Sprintf("Missing %s %s in test matrix", result.Entry.Database.Label(), result.Entry.Cycle)
+	default:
+		return fmt.Sprintf("Review %s %s in test matrix", result.Entry.Database.Label(), result.Entry.Cycle)
+	}
+}
+
+func annotationMessage(result matrixCheckResult) string {
+	return fmt.Sprintf("status=%s current=%s latest=%s eol=%s notes=%s",
+		resultSeverityFor(result).Circle(),
+		result.Entry.Version,
+		result.Latest,
+		result.EOL,
+		resultNotes(result),
+	)
 }
 
 func resultSummary(results []matrixCheckResult, severity resultSeverity) string {
@@ -316,10 +425,24 @@ func resultSummary(results []matrixCheckResult, severity resultSeverity) string 
 	}
 }
 
+func markdownCell(value string) string {
+	value = strings.ReplaceAll(value, "\r", " ")
+	value = strings.ReplaceAll(value, "\n", " ")
+	value = strings.ReplaceAll(value, "|", "\\|")
+	return value
+}
+
 func githubActionsEscape(message string) string {
 	message = strings.ReplaceAll(message, "%", "%25")
 	message = strings.ReplaceAll(message, "\r", "%0D")
 	message = strings.ReplaceAll(message, "\n", "%0A")
+	return message
+}
+
+func githubActionsPropertyEscape(message string) string {
+	message = githubActionsEscape(message)
+	message = strings.ReplaceAll(message, ":", "%3A")
+	message = strings.ReplaceAll(message, ",", "%2C")
 	return message
 }
 

--- a/scripts/update-test-matrix_test.go
+++ b/scripts/update-test-matrix_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/zph/terraform-provider-mysql/v3/internal/testmatrix"
 )
@@ -72,6 +73,43 @@ func TestMaxResultSeverity(t *testing.T) {
 
 	if got := maxResultSeverity(results); got != severityRed {
 		t.Fatalf("maxResultSeverity with red = %v, want %v", got, severityRed)
+	}
+}
+
+func TestEOLCriticalSeverityAndNotes(t *testing.T) {
+	result := matrixCheckResult{
+		Entry:       testmatrix.Entry{Database: testmatrix.MySQL, Cycle: "5.7", Version: "5.7.44"},
+		EOLWarning:  true,
+		EOLCritical: true,
+	}
+
+	if got := resultSeverityFor(result); got != severityRed {
+		t.Fatalf("resultSeverityFor() = %v, want %v", got, severityRed)
+	}
+	if got := resultNotes(result); got != "🟢/🔴" {
+		t.Fatalf("resultNotes() = %q, want %q", got, "🟢/🔴")
+	}
+}
+
+func TestEOLIsOlderThanPolicy(t *testing.T) {
+	eolDate := time.Date(2024, 6, 13, 0, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name string
+		now  time.Time
+		want bool
+	}{
+		{name: "before two years", now: time.Date(2026, 6, 12, 23, 59, 59, 0, time.UTC), want: false},
+		{name: "exactly two years", now: time.Date(2026, 6, 13, 0, 0, 0, 0, time.UTC), want: false},
+		{name: "after two years", now: time.Date(2026, 6, 13, 0, 0, 1, 0, time.UTC), want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := eolIsOlderThanPolicy(eolDate, tt.now); got != tt.want {
+				t.Fatalf("eolIsOlderThanPolicy() = %t, want %t", got, tt.want)
+			}
+		})
 	}
 }
 

--- a/scripts/update-test-matrix_test.go
+++ b/scripts/update-test-matrix_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/zph/terraform-provider-mysql/v3/internal/testmatrix"
@@ -79,5 +80,42 @@ func TestResultSummaryEscapesGitHubActionsMessage(t *testing.T) {
 	want := "patch 100%25%0Asecond line%0D"
 	if message != want {
 		t.Fatalf("githubActionsEscape() = %q, want %q", message, want)
+	}
+}
+
+func TestGitHubActionsPropertyEscape(t *testing.T) {
+	message := githubActionsPropertyEscape("matrix: mysql, 100%\n")
+	want := "matrix%3A mysql%2C 100%25%0A"
+	if message != want {
+		t.Fatalf("githubActionsPropertyEscape() = %q, want %q", message, want)
+	}
+}
+
+func TestGitHubStepSummaryIncludesNonGreenRows(t *testing.T) {
+	results := []matrixCheckResult{
+		{Entry: testmatrix.Entry{Database: testmatrix.MySQL, Cycle: "8.0", Version: "8.0"}, Latest: "8.0", EOL: "2032-04-30"},
+		{Entry: testmatrix.Entry{Database: testmatrix.TiDB, Cycle: "8.5", Version: "8.5.5"}, Latest: "8.5.6", EOL: "2028-12-19", PatchWarning: true},
+		{Entry: testmatrix.Entry{Database: testmatrix.MariaDB, Cycle: "11.8", Version: "-"}, Latest: "11.8.8", EOL: "2028-06-04", NewerLine: true},
+	}
+
+	summary := githubStepSummary(results, severityRed)
+	mustContain(t, summary, "## Matrix Version Policy")
+	mustContain(t, summary, "**Failing:**")
+	mustContain(t, summary, "| 🔴 | MariaDB | 11.8 | - | 11.8.8 | 2028-06-04 | 🔴/🟢 |")
+	mustContain(t, summary, "| 🟡 | TiDB | 8.5 | 8.5.5 | 8.5.6 | 2028-12-19 | 🟡/🟢 |")
+	mustNotContain(t, summary, "| 🟢 | MySQL | 8.0 |")
+}
+
+func mustContain(t *testing.T, haystack, needle string) {
+	t.Helper()
+	if !strings.Contains(haystack, needle) {
+		t.Fatalf("expected %q to contain %q", haystack, needle)
+	}
+}
+
+func mustNotContain(t *testing.T, haystack, needle string) {
+	t.Helper()
+	if strings.Contains(haystack, needle) {
+		t.Fatalf("expected %q not to contain %q", haystack, needle)
 	}
 }

--- a/scripts/update-test-matrix_test.go
+++ b/scripts/update-test-matrix_test.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/zph/terraform-provider-mysql/v3/internal/testmatrix"
+)
+
+func TestMariaDBCommunityEOLDate(t *testing.T) {
+	originalCache := textCache
+	textCache = map[string]string{
+		mariadbMaintenancePolicySource: `
+			<table>
+				<tr><td>12.3</td><td>TBC</td><td>TBC</td><td>TBC</td><td>TBC</td></tr>
+				<tr><td>11.8</td><td>4 Jun 2025</td><td>4 Jun 2028</td><td>22 Oct 2030</td><td>22 Oct 2033</td></tr>
+			</table>
+		`,
+	}
+	defer func() { textCache = originalCache }()
+
+	eol, err := mariadbCommunityEOLDate(&http.Client{}, "11.8")
+	if err != nil {
+		t.Fatalf("expected MariaDB 11.8 EOL date: %v", err)
+	}
+	if eol != "2028-06-04" {
+		t.Fatalf("expected MariaDB 11.8 EOL 2028-06-04, got %q", eol)
+	}
+
+	if _, err := mariadbCommunityEOLDate(&http.Client{}, "12.3"); err == nil {
+		t.Fatal("expected MariaDB 12.3 TBC maintenance dates to be rejected")
+	}
+}
+
+func TestRawMessageIsTruthy(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  json.RawMessage
+		want bool
+	}{
+		{name: "missing", raw: nil, want: false},
+		{name: "false bool", raw: json.RawMessage(`false`), want: false},
+		{name: "true bool", raw: json.RawMessage(`true`), want: true},
+		{name: "date string", raw: json.RawMessage(`"2023-07-18"`), want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := rawMessageIsTruthy(tt.raw); got != tt.want {
+				t.Fatalf("rawMessageIsTruthy(%s) = %t, want %t", tt.raw, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMaxResultSeverity(t *testing.T) {
+	results := []matrixCheckResult{
+		{Entry: testmatrix.Entry{Database: testmatrix.MySQL, Cycle: "8.0", Version: "8.0"}},
+		{Entry: testmatrix.Entry{Database: testmatrix.TiDB, Cycle: "8.5", Version: "8.5.5"}, PatchWarning: true},
+	}
+
+	if got := maxResultSeverity(results); got != severityYellow {
+		t.Fatalf("maxResultSeverity without red = %v, want %v", got, severityYellow)
+	}
+
+	results = append(results, matrixCheckResult{
+		Entry:     testmatrix.Entry{Database: testmatrix.MariaDB, Cycle: "11.8", Version: "-"},
+		NewerLine: true,
+	})
+
+	if got := maxResultSeverity(results); got != severityRed {
+		t.Fatalf("maxResultSeverity with red = %v, want %v", got, severityRed)
+	}
+}
+
+func TestResultSummaryEscapesGitHubActionsMessage(t *testing.T) {
+	message := githubActionsEscape("patch 100%\nsecond line\r")
+	want := "patch 100%25%0Asecond line%0D"
+	if message != want {
+		t.Fatalf("githubActionsEscape() = %q, want %q", message, want)
+	}
+}


### PR DESCRIPTION
## Summary

- Centralize the database test matrix in `internal/testmatrix` and use that shared data from the Makefile, GitHub Actions, and the Go test runner.
- Update the matrix to current retained lines and latest patch versions across MySQL, Percona Server, MariaDB, and TiDB.
- Add fast unit-test targets that run before testcontainers integration coverage.
- Add matrix version policy checks for latest patch drift, supported line coverage, and the two-year post-EOL retention policy.
- Report matrix policy results in CI with a job summary and sticky PR comment; red rows fail CI and yellow rows report warnings.
- Document the CI matrix policy and the GitHub Actions release-build provenance in the README.

## Matrix Policy

The branch makes `internal/testmatrix/matrix.go` the source of truth for tested database versions. The policy is:

- test the latest patch version for each selected major/minor line;
- include all supported major/minor lines;
- keep EOL major/minor lines for two years after EOL;
- mark lines more than two years past EOL as red and fail the CI policy job.

Current matrix entries include:

- MySQL: 8.0.46, 8.4.9, 9.7.0
- Percona Server: 8.0.46-37, 8.4.8-8
- MariaDB: 10.11.18, 11.4.12, 11.8.8
- TiDB: 6.1.7, 6.5.12, 7.1.6, 7.5.7, 8.1.2, 8.5.6

## Make Targets

- `make test` runs unit tests first, then integration tests.
- `make test-unit` runs pure Go/Terraform tests without testcontainers or external database servers.
- `make test-integration` runs the testcontainers matrix.
- `make testcontainers-db DB=<db> VERSION=<version>` runs one matrix entry.
- `make eol-versions` prints the policy table locally.
- `make eol-versions-ci` enforces the red-row policy in CI.

## Validation

- `git diff --check`
- `go test ./internal/testmatrix`
- `go test scripts/update-test-matrix.go scripts/update-test-matrix_test.go`
- `go run scripts/test-matrix.go --github-actions`
- `make eol-versions`
- `make eol-versions-ci`
