### PR TITLE
Cover TiDB runaway query controls

### DIFF
--- a/docs/resources/grant.md
+++ b/docs/resources/grant.md
@@ -63,6 +63,20 @@ resource "mysql_grant" "developer" {
 }
 ```
 
+## Granting TiDB Resource Control Privileges
+
+TiDB resource group operations such as `CREATE RESOURCE GROUP`, `ALTER RESOURCE GROUP`, and `DROP RESOURCE GROUP` require `SUPER` or `RESOURCE_GROUP_ADMIN`. When TiDB resource-control strict mode is enabled, `SET RESOURCE GROUP` requires `SUPER`, `RESOURCE_GROUP_ADMIN`, or `RESOURCE_GROUP_USER`.
+
+```hcl
+resource "mysql_grant" "resource_control" {
+  user       = mysql_user.operator.user
+  host       = mysql_user.operator.host
+  database   = "*"
+  table      = "*"
+  privileges = ["RESOURCE_GROUP_ADMIN", "RESOURCE_GROUP_USER"]
+}
+```
+
 ## Argument Reference
 
 ~> **Note:** MySQL removed the `REQUIRE` option from `GRANT` in version 8. `tls_option` is ignored in MySQL 8 and above.

--- a/docs/resources/ti_resource_group.md
+++ b/docs/resources/ti_resource_group.md
@@ -47,6 +47,17 @@ resource "mysql_ti_resource_group" "oltp" {
 }
 ```
 
+### Resource group with v8.5 runaway query controls
+
+```hcl
+resource "mysql_ti_resource_group" "oltp_guardrail" {
+  name           = "oltp_guardrail"
+  resource_units = 2000
+  priority       = "high"
+  query_limit    = "PROCESSED_KEYS=1000000, RU=2000, ACTION=SWITCH_GROUP(rg_quarantine), WATCH=PLAN DURATION='30m'"
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -55,7 +66,7 @@ The following arguments are supported:
 * `resource_units` - (Required) The number of Request Units per second (RU_PER_SEC) allocated to this resource group. This controls the throughput capacity. When reading existing TiDB resource groups, the provider maps TiDB's `UNLIMITED` value to `2147483647`.
 * `priority` - (Optional) The priority level of the resource group. Must be one of `high`, `medium`, or `low`. Defaults to `medium`.
 * `burstable` - (Optional) Whether the resource group can burst beyond its allocated RU_PER_SEC when there is spare capacity. Defaults to `false`.
-* `query_limit` - (Optional) Runaway query control settings. When set, queries matching the criteria are automatically handled. Format: `EXEC_ELAPSED='<duration>', ACTION=<KILL|COOLDOWN|DRYRUN>, WATCH=<EXACT|SIMILAR|PLAN> DURATION='<duration>'`. When empty (default), no query limit is applied.
+* `query_limit` - (Optional) Runaway query control settings. When set, queries matching the criteria are automatically handled. This is the body of TiDB's `QUERY_LIMIT=(...)` clause. Supported TiDB criteria include `EXEC_ELAPSED='<duration>'`, `PROCESSED_KEYS=<count>`, and `RU=<count>`. Supported actions include `DRYRUN`, `COOLDOWN`, `KILL`, and, in TiDB v8.4.0 and later including v8.5.x, `SWITCH_GROUP(<resource_group>)`. The `WATCH` clause can use `EXACT`, `SIMILAR`, or `PLAN` with an optional `DURATION='<duration>'`. When empty (default), no query limit is applied.
 
 ## Attributes Reference
 

--- a/mysql/resource_grant_unit_test.go
+++ b/mysql/resource_grant_unit_test.go
@@ -57,6 +57,31 @@ func TestParseGrantFromRowTableGrant(t *testing.T) {
 	}
 }
 
+func TestParseGrantFromRowTiDBResourceControlPrivileges(t *testing.T) {
+	grant, err := parseGrantFromRow("GRANT RESOURCE_GROUP_ADMIN, RESOURCE_GROUP_USER ON *.* TO 'ops'@'%'")
+	if err != nil {
+		t.Fatalf("parseGrantFromRow returned error: %s", err)
+	}
+
+	tableGrant, ok := grant.(*TablePrivilegeGrant)
+	if !ok {
+		t.Fatalf("parseGrantFromRow returned %T, want *TablePrivilegeGrant", grant)
+	}
+	if tableGrant.Database != "*" {
+		t.Fatalf("Database = %q, want *", tableGrant.Database)
+	}
+	if tableGrant.Table != "*" {
+		t.Fatalf("Table = %q, want *", tableGrant.Table)
+	}
+	wantPrivileges := []string{"RESOURCE_GROUP_ADMIN", "RESOURCE_GROUP_USER"}
+	if !reflect.DeepEqual(tableGrant.Privileges, wantPrivileges) {
+		t.Fatalf("Privileges = %#v, want %#v", tableGrant.Privileges, wantPrivileges)
+	}
+	if !tableGrant.UserOrRole.Equals(UserOrRole{Name: "ops", Host: "%"}) {
+		t.Fatalf("UserOrRole = %#v", tableGrant.UserOrRole)
+	}
+}
+
 func TestParseGrantFromRowProcedureGrant(t *testing.T) {
 	grant, err := parseGrantFromRow("GRANT EXECUTE ON PROCEDURE `app_db`.`rotate_keys` TO 'app'@'localhost'")
 	if err != nil {
@@ -159,6 +184,33 @@ func TestParseResourceFromDataTableGrant(t *testing.T) {
 		t.Fatalf("Privileges = %#v", tableGrant.Privileges)
 	}
 	if got := tableGrant.SQLGrantStatement(); got != "GRANT SELECT, UPDATE(C1, C2) ON `app_db`.`accounts` TO 'app'@'%' REQUIRE SSL WITH GRANT OPTION" {
+		t.Fatalf("SQLGrantStatement() = %q", got)
+	}
+}
+
+func TestParseResourceFromDataTiDBResourceControlPrivileges(t *testing.T) {
+	d := schema.TestResourceDataRaw(t, resourceGrant().Schema, map[string]interface{}{
+		"user":       "ops",
+		"host":       "%",
+		"database":   "*",
+		"table":      "*",
+		"privileges": []interface{}{"resource_group_user", "resource_group_admin"},
+	})
+
+	grant, diagErr := parseResourceFromData(d)
+	if diagErr.HasError() {
+		t.Fatalf("parseResourceFromData returned diagnostics: %s", diagErr[0].Summary)
+	}
+
+	tableGrant, ok := grant.(*TablePrivilegeGrant)
+	if !ok {
+		t.Fatalf("parseResourceFromData returned %T, want *TablePrivilegeGrant", grant)
+	}
+	wantPrivileges := []string{"RESOURCE_GROUP_ADMIN", "RESOURCE_GROUP_USER"}
+	if !reflect.DeepEqual(tableGrant.Privileges, wantPrivileges) {
+		t.Fatalf("Privileges = %#v, want %#v", tableGrant.Privileges, wantPrivileges)
+	}
+	if got := tableGrant.SQLGrantStatement(); got != "GRANT RESOURCE_GROUP_ADMIN, RESOURCE_GROUP_USER ON *.* TO 'ops'@'%'" {
 		t.Fatalf("SQLGrantStatement() = %q", got)
 	}
 }

--- a/mysql/resource_ti_resource_group_unit_test.go
+++ b/mysql/resource_ti_resource_group_unit_test.go
@@ -37,6 +37,41 @@ func TestResourceGroupBuildSQLQueryEmptyQueryLimit(t *testing.T) {
 	}
 }
 
+func TestResourceGroupBuildSQLQueryRunawayQueryControls(t *testing.T) {
+	tests := []struct {
+		name       string
+		queryLimit string
+		want       string
+	}{
+		{
+			name:       "dry run elapsed time",
+			queryLimit: "EXEC_ELAPSED='5s', ACTION=DRYRUN",
+			want:       "ALTER RESOURCE GROUP rg_runaway RU_PER_SEC = 5000 PRIORITY = MEDIUM QUERY_LIMIT=(EXEC_ELAPSED='5s', ACTION=DRYRUN) BURSTABLE = false ;",
+		},
+		{
+			name:       "processed keys and ru switch group",
+			queryLimit: "PROCESSED_KEYS=1000000, RU=2000, ACTION=SWITCH_GROUP(rg_quarantine), WATCH=PLAN DURATION='30m'",
+			want:       "ALTER RESOURCE GROUP rg_runaway RU_PER_SEC = 5000 PRIORITY = MEDIUM QUERY_LIMIT=(PROCESSED_KEYS=1000000, RU=2000, ACTION=SWITCH_GROUP(rg_quarantine), WATCH=PLAN DURATION='30m') BURSTABLE = false ;",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rg := ResourceGroup{
+				Name:          "rg_runaway",
+				ResourceUnits: 5000,
+				Priority:      "MEDIUM",
+				Burstable:     false,
+				QueryLimit:    tt.queryLimit,
+			}
+
+			if got := rg.buildSQLQuery(UpdateResourceGroupSQLPrefix); got != tt.want {
+				t.Fatalf("buildSQLQuery() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestResourceGroupResourceDataMapping(t *testing.T) {
 	d := schema.TestResourceDataRaw(t, resourceTiResourceGroup().Schema, map[string]interface{}{
 		"name":           "rg100",


### PR DESCRIPTION
TiDB 8.5 includes the v8.4 resource-control additions for runaway queries: PROCESSED_KEYS and RU triggers, SWITCH_GROUP actions, and PLAN watches. The provider already passes query_limit through as TiDB SQL, so add unit coverage that proves those forms are preserved in generated RESOURCE GROUP statements.

Also add coverage and documentation for the TiDB resource-control dynamic privileges RESOURCE_GROUP_ADMIN and RESOURCE_GROUP_USER, which are required for resource group administration and strict SET RESOURCE GROUP usage.

Fixes #31
