### PR TITLE
Add TiDB syntax coverage for resource controls and placement

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,7 @@ help: ## Show this help message
 	@echo '  make test-unit          Run unit tests without testcontainers'
 	@echo '  make test-integration   Run testcontainers integration matrix'
 	@echo '  make testcontainers-db DB=mysql VERSION=8.0'
+	@echo '  make clean-testcontainers Remove stopped testcontainers artifacts'
 	@echo '  make eol-versions      Check matrix patch drift and EOL warnings'
 	@echo '  make eol-versions-ci   Enforce matrix version policy for CI'
 	@echo '  make test VERBOSE=1    Run unit and integration tests, streaming integration output'
@@ -62,7 +63,7 @@ default: help
 build: fmtcheck ## Build the provider
 	go install
 
-clean: ## Aggressively clear Docker cache and test artifacts
+clean: clean-testcontainers ## Aggressively clear Docker cache and test artifacts
 	@echo "Clearing Docker cache and test artifacts..."
 	@# Remove testcontainers-related images (mysql, percona, mariadb, tidb)
 	@docker images --format "{{.Repository}}:{{.Tag}}" | grep -E "(mysql|percona|mariadb|tidb|pingcap)" | xargs -r docker rmi -f 2>/dev/null || true
@@ -83,6 +84,25 @@ clean: ## Aggressively clear Docker cache and test artifacts
 	@# Clear Docker's content-addressable storage for problematic images (if possible)
 	@echo "Docker cache cleared. Note: For MySQL 5.7 and Percona on Apple Silicon,"
 	@echo "you may need to restart Docker Desktop to fully clear manifest cache."
+
+clean-testcontainers: ## Remove stopped testcontainers containers, networks, volumes, images, and logs
+	@echo "Cleaning testcontainers artifacts..."
+	@found=0; \
+	for runtime in docker podman; do \
+		if command -v $$runtime >/dev/null 2>&1; then \
+			found=1; \
+			echo "Cleaning $$runtime testcontainers artifacts..."; \
+			TMPDIR="$${TMPDIR:-/tmp}" $$runtime container prune --filter label=org.testcontainers=true -f 2>/dev/null || true; \
+			TMPDIR="$${TMPDIR:-/tmp}" $$runtime network prune --filter label=org.testcontainers=true -f 2>/dev/null || true; \
+			TMPDIR="$${TMPDIR:-/tmp}" $$runtime volume prune --filter label=org.testcontainers=true -f 2>/dev/null || true; \
+			TMPDIR="$${TMPDIR:-/tmp}" $$runtime image prune -a --filter label=org.testcontainers=true -f 2>/dev/null || true; \
+		fi; \
+	done; \
+	if [ $$found -eq 0 ]; then \
+		echo "No docker or podman CLI found; skipping container runtime cleanup."; \
+	fi
+	@rm -rf /tmp/testcontainers-* /private/tmp/testcontainers-* 2>/dev/null || true
+	@echo "Testcontainers artifacts cleaned."
 
 build-tiup-playground-image: ## Pre-build TiUP Playground Docker image for caching
 	@echo "Building TiUP Playground Docker image..."
@@ -385,4 +405,4 @@ release-local: ## Create a release locally (for testing - use 'make release' for
 release: ## Create a release PR branch (tag, push branch and tag, then create PR to merge to default branch)
 	@go run scripts/make-release.go
 
-.PHONY: help build test test-unit test-integration test-sequential testcontainers-matrix testcontainers-image testcontainers-db eol-versions eol-versions-ci testcontainers-matrix-check testcontainers-matrix-update testacc acceptance vet fmt fmtcheck errcheck vendor-status test-compile website website-test tag format-tag release release-local
+.PHONY: help build clean clean-testcontainers test test-unit test-integration test-sequential testcontainers-matrix testcontainers-image testcontainers-db eol-versions eol-versions-ci testcontainers-matrix-check testcontainers-matrix-update testacc acceptance vet fmt fmtcheck errcheck vendor-status test-compile website website-test tag format-tag release release-local

--- a/docs/IMPLEMENTATION.md
+++ b/docs/IMPLEMENTATION.md
@@ -46,6 +46,7 @@ scripts/
 | `mysql_ti_resource_group` | `resource_ti_resource_group.go` | Resource group management (v7.5+) |
 | `mysql_ti_resource_group_user_assignment` | `resource_ti_resource_group_user_assignment.go` | User-to-resource-group binding |
 | `mysql_ti_placement_policy` | `resource_ti_placement_policy.go` | Placement policies for data distribution |
+| `mysql_ti_placement_range_policy` | `resource_ti_placement_range_policy.go` | Global/meta range placement policy assignment |
 
 ### Data Sources
 | Data Source | File | Description |

--- a/docs/data-sources/ti_placement_labels.md
+++ b/docs/data-sources/ti_placement_labels.md
@@ -1,0 +1,26 @@
+---
+layout: "mysql"
+page_title: "MySQL: mysql_ti_placement_labels"
+sidebar_current: "docs-mysql-datasource-ti-placement-labels"
+description: |-
+  Lists TiDB placement labels available in the cluster.
+---
+
+# mysql\_ti\_placement\_labels
+
+The `mysql_ti_placement_labels` data source reads TiDB placement labels using [`SHOW PLACEMENT LABELS`](https://docs.pingcap.com/tidb/stable/sql-statement-show-placement-labels/). These labels are useful when building TiDB placement policies.
+
+## Example Usage
+
+```hcl
+data "mysql_ti_placement_labels" "available" {}
+```
+
+## Attributes Reference
+
+* `labels` - List of placement labels.
+
+Each `labels` item contains:
+
+* `key` - Placement label key, such as `region` or `zone`.
+* `values` - Available values for the label.

--- a/docs/index.md
+++ b/docs/index.md
@@ -117,6 +117,8 @@ This provider includes resources for managing TiDB-specific features:
 * `mysql_ti_resource_group` - Create and manage TiDB resource groups for workload isolation
 * `mysql_ti_resource_group_user_assignment` - Assign users to TiDB resource groups
 * `mysql_ti_placement_policy` - Create and manage TiDB placement policies for data distribution
+* `mysql_ti_placement_range_policy` - Apply TiDB placement policies to the global or metadata range
+* `mysql_ti_placement_labels` - List TiDB placement labels available in the cluster
 
 These resources use TiDB-specific SQL extensions and are not compatible with standard MySQL.
 

--- a/docs/resources/global_variable.md
+++ b/docs/resources/global_variable.md
@@ -13,7 +13,7 @@ server.
 
 ~> **Note on MySQL:** MySQL global variables are [not persistent](https://dev.mysql.com/doc/refman/5.7/en/set-variable.html)
 
-~> **Note on TiDB:** TiDB global variables are [persistent](https://docs.pingcap.com/tidb/v5.4/sql-statement-set-variable#mysql-compatibility)
+~> **Note on TiDB:** TiDB global variables are [persistent](https://docs.pingcap.com/tidb/stable/sql-statement-set-variable/#mysql-compatibility). Use this resource for TiDB `SET GLOBAL` settings such as resource-control feature flags; do not use it for session-only statements such as `SET RESOURCE GROUP`.
 
 ~> **Note about `destroy`:** `destroy` will try assign `DEFAULT` value for global variable.
   Unfortunately not every variable support this.
@@ -24,6 +24,15 @@ server.
 resource "mysql_global_variable" "max_connections" {
   name = "max_connections"
   value = "100"
+}
+```
+
+### TiDB resource control variable
+
+```hcl
+resource "mysql_global_variable" "tidb_enable_resource_control" {
+  name  = "tidb_enable_resource_control"
+  value = "ON"
 }
 ```
 

--- a/docs/resources/grant.md
+++ b/docs/resources/grant.md
@@ -63,6 +63,20 @@ resource "mysql_grant" "developer" {
 }
 ```
 
+## Granting TiDB Resource Control Privileges
+
+TiDB resource group operations such as `CREATE RESOURCE GROUP`, `ALTER RESOURCE GROUP`, and `DROP RESOURCE GROUP` require `SUPER` or `RESOURCE_GROUP_ADMIN`. When TiDB resource-control strict mode is enabled, `SET RESOURCE GROUP` requires `SUPER`, `RESOURCE_GROUP_ADMIN`, or `RESOURCE_GROUP_USER`.
+
+```hcl
+resource "mysql_grant" "resource_control" {
+  user       = mysql_user.operator.user
+  host       = mysql_user.operator.host
+  database   = "*"
+  table      = "*"
+  privileges = ["RESOURCE_GROUP_ADMIN", "RESOURCE_GROUP_USER"]
+}
+```
+
 ## Argument Reference
 
 ~> **Note:** MySQL removed the `REQUIRE` option from `GRANT` in version 8. `tls_option` is ignored in MySQL 8 and above.

--- a/docs/resources/ti_placement_policy.md
+++ b/docs/resources/ti_placement_policy.md
@@ -8,7 +8,7 @@ description: |-
 
 # mysql\_ti\_placement\_policy
 
-The `mysql_ti_placement_policy` resource creates and manages [TiDB placement policies](https://docs.pingcap.com/tidb/stable/placement-rules-in-sql) which control how data is distributed across TiKV nodes, regions, and availability zones.
+The `mysql_ti_placement_policy` resource creates and manages [TiDB placement policies](https://docs.pingcap.com/tidb/stable/placement-rules-in-sql) which control how data is distributed across TiKV nodes, regions, and availability zones. The SQL syntax follows TiDB's [`CREATE PLACEMENT POLICY`](https://docs.pingcap.com/tidb/stable/sql-statement-create-placement-policy/) and [`ALTER PLACEMENT POLICY`](https://docs.pingcap.com/tidb/stable/sql-statement-alter-placement-policy/) statements.
 
 ~> **Note:** This resource is only compatible with TiDB clusters. It will not work with standard MySQL or MariaDB.
 
@@ -30,6 +30,24 @@ resource "mysql_ti_placement_policy" "us_east" {
 resource "mysql_ti_placement_policy" "ssd_only" {
   name        = "ssd_only"
   constraints = ["+disk=ssd"]
+}
+```
+
+### Placement policy with replica and role-specific constraints
+
+```hcl
+resource "mysql_ti_placement_policy" "multi_region" {
+  name                  = "multi_region"
+  primary_region        = "us-east-1"
+  regions               = ["us-east-1", "us-west-2"]
+  followers             = 4
+  learners              = 1
+  schedule              = "EVEN"
+  constraints           = ["+disk=ssd"]
+  leader_constraints    = ["+zone=us-east-1a"]
+  follower_constraints  = ["+zone=us-west-2a"]
+  learner_constraints   = ["+zone=us-west-2b"]
+  survival_preferences  = ["region", "zone"]
 }
 ```
 
@@ -55,7 +73,14 @@ The following arguments are supported:
 * `name` - (Required, ForceNew) The name of the placement policy. Changing this forces a new resource.
 * `primary_region` - (Optional) The primary region for leader replicas. Leaders will preferentially be placed in this region.
 * `regions` - (Optional) A list of regions where data replicas can be placed. Order may influence follower placement preference.
+* `followers` - (Optional) Number of follower replicas.
+* `schedule` - (Optional) TiDB placement schedule strategy.
+* `learners` - (Optional) Number of learner replicas.
 * `constraints` - (Optional) A list of label constraints that control replica placement. Uses the format `+key=value` to require a label or `-key=value` to prohibit it. When omitted or empty, no constraints are applied.
+* `leader_constraints` - (Optional) Label constraints for leader replicas.
+* `follower_constraints` - (Optional) Label constraints for follower replicas.
+* `learner_constraints` - (Optional) Label constraints for learner replicas.
+* `survival_preferences` - (Optional) Ordered labels for TiDB's `SURVIVAL_PREFERENCES` clause. TiDB accepts this in `CREATE/ALTER PLACEMENT POLICY`, but the documented `information_schema.placement_policies` table does not expose it for drift detection.
 
 ## Attributes Reference
 

--- a/docs/resources/ti_placement_range_policy.md
+++ b/docs/resources/ti_placement_range_policy.md
@@ -1,0 +1,47 @@
+---
+layout: "mysql"
+page_title: "MySQL: mysql_ti_placement_range_policy"
+sidebar_current: "docs-mysql-resource-ti-placement-range-policy"
+description: |-
+  Applies a TiDB placement policy to the global or metadata range.
+---
+
+# mysql\_ti\_placement\_range\_policy
+
+The `mysql_ti_placement_range_policy` resource applies a TiDB placement policy to the `global` or `meta` range using [`ALTER RANGE`](https://docs.pingcap.com/tidb/stable/sql-statement-alter-range/).
+
+~> **Note:** TiDB readback uses [`SHOW PLACEMENT`](https://docs.pingcap.com/tidb/stable/placement-rules-in-sql/), which returns the expanded placement and scheduling state for the range. It does not return the original placement policy name, so this resource cannot fully detect out-of-band changes to the assigned policy name.
+
+## Example Usage
+
+```hcl
+resource "mysql_ti_placement_policy" "five_replicas" {
+  name      = "five_replicas"
+  followers = 4
+}
+
+resource "mysql_ti_placement_range_policy" "global" {
+  range            = "global"
+  placement_policy = mysql_ti_placement_policy.five_replicas.name
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `range` - (Required, ForceNew) TiDB range to configure. Must be `global` or `meta`.
+* `placement_policy` - (Required) Placement policy to apply to the range.
+
+## Attributes Reference
+
+* `placement` - Expanded placement text returned by `SHOW PLACEMENT`.
+* `scheduling_state` - Placement scheduling state returned by `SHOW PLACEMENT`.
+
+## Import
+
+Range placement policies can be imported using the range name.
+
+```shell
+terraform import mysql_ti_placement_range_policy.global global
+```

--- a/docs/resources/ti_resource_group.md
+++ b/docs/resources/ti_resource_group.md
@@ -8,7 +8,7 @@ description: |-
 
 # mysql\_ti\_resource\_group
 
-The `mysql_ti_resource_group` resource creates and manages [TiDB resource groups](https://docs.pingcap.com/tidb/stable/tidb-resource-control) for workload isolation and prioritization using Request Units (RU).
+The `mysql_ti_resource_group` resource creates and manages [TiDB resource groups](https://docs.pingcap.com/tidb/stable/tidb-resource-control-ru-groups/) for workload isolation and prioritization using Request Units (RU). The SQL syntax follows TiDB's [`CREATE RESOURCE GROUP`](https://docs.pingcap.com/tidb/stable/sql-statement-create-resource-group/) and [`ALTER RESOURCE GROUP`](https://docs.pingcap.com/tidb/stable/sql-statement-alter-resource-group/) statements.
 
 ~> **Note:** This resource requires TiDB v7.5.0 or later.
 
@@ -36,6 +36,17 @@ resource "mysql_ti_resource_group" "batch_jobs" {
 }
 ```
 
+### Resource group with TiDB v9 burstable mode
+
+```hcl
+resource "mysql_ti_resource_group" "interactive" {
+  name           = "interactive"
+  resource_units = 1000
+  priority       = "high"
+  burstable_mode = "unlimited"
+}
+```
+
 ### Resource group with query limit (runaway query control)
 
 ```hcl
@@ -58,6 +69,19 @@ resource "mysql_ti_resource_group" "oltp_guardrail" {
 }
 ```
 
+### Default resource group background task limits
+
+TiDB only supports `BACKGROUND` on the `default` resource group. See [TiDB background task resource control](https://docs.pingcap.com/tidb/stable/tidb-resource-control-background-tasks/).
+
+```hcl
+resource "mysql_ti_resource_group" "default" {
+  name           = "default"
+  resource_units = 2147483647
+  burstable_mode = "unlimited"
+  background     = "TASK_TYPES='br,ddl', UTILIZATION_LIMIT=30"
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -65,8 +89,10 @@ The following arguments are supported:
 * `name` - (Required, ForceNew) The name of the resource group. Changing this forces a new resource.
 * `resource_units` - (Required) The number of Request Units per second (RU_PER_SEC) allocated to this resource group. This controls the throughput capacity. When reading existing TiDB resource groups, the provider maps TiDB's `UNLIMITED` value to `2147483647`.
 * `priority` - (Optional) The priority level of the resource group. Must be one of `high`, `medium`, or `low`. Defaults to `medium`.
-* `burstable` - (Optional) Whether the resource group can burst beyond its allocated RU_PER_SEC when there is spare capacity. Defaults to `false`.
+* `burstable` - (Optional) Legacy boolean form for whether the resource group can burst beyond its allocated RU_PER_SEC when there is spare capacity. Defaults to `false`.
+* `burstable_mode` - (Optional, Computed) TiDB v9.0+ burst mode. Must be one of `off`, `moderated`, or `unlimited`. When set, this takes precedence over `burstable`.
 * `query_limit` - (Optional) Runaway query control settings. When set, queries matching the criteria are automatically handled. This is the body of TiDB's `QUERY_LIMIT=(...)` clause. Supported TiDB criteria include `EXEC_ELAPSED='<duration>'`, `PROCESSED_KEYS=<count>`, and `RU=<count>`. Supported actions include `DRYRUN`, `COOLDOWN`, `KILL`, and, in TiDB v8.4.0 and later including v8.5.x, `SWITCH_GROUP(<resource_group>)`. The `WATCH` clause can use `EXACT`, `SIMILAR`, or `PLAN` with an optional `DURATION='<duration>'`. When empty (default), no query limit is applied.
+* `background` - (Optional, Computed) Raw body for TiDB's `BACKGROUND=(...)` resource group clause. TiDB currently supports this only on the `default` resource group. Use `NULL` to emit `BACKGROUND=NULL`.
 
 ## Attributes Reference
 

--- a/docs/resources/ti_resource_group.md
+++ b/docs/resources/ti_resource_group.md
@@ -36,17 +36,6 @@ resource "mysql_ti_resource_group" "batch_jobs" {
 }
 ```
 
-### Resource group with TiDB v9 burstable mode
-
-```hcl
-resource "mysql_ti_resource_group" "interactive" {
-  name           = "interactive"
-  resource_units = 1000
-  priority       = "high"
-  burstable_mode = "unlimited"
-}
-```
-
 ### Resource group with query limit (runaway query control)
 
 ```hcl
@@ -77,7 +66,7 @@ TiDB only supports `BACKGROUND` on the `default` resource group. See [TiDB backg
 resource "mysql_ti_resource_group" "default" {
   name           = "default"
   resource_units = 2147483647
-  burstable_mode = "unlimited"
+  burstable      = true
   background     = "TASK_TYPES='br,ddl', UTILIZATION_LIMIT=30"
 }
 ```
@@ -90,7 +79,6 @@ The following arguments are supported:
 * `resource_units` - (Required) The number of Request Units per second (RU_PER_SEC) allocated to this resource group. This controls the throughput capacity. When reading existing TiDB resource groups, the provider maps TiDB's `UNLIMITED` value to `2147483647`.
 * `priority` - (Optional) The priority level of the resource group. Must be one of `high`, `medium`, or `low`. Defaults to `medium`.
 * `burstable` - (Optional) Legacy boolean form for whether the resource group can burst beyond its allocated RU_PER_SEC when there is spare capacity. Defaults to `false`.
-* `burstable_mode` - (Optional, Computed) TiDB v9.0+ burst mode. Must be one of `off`, `moderated`, or `unlimited`. When set, this takes precedence over `burstable`.
 * `query_limit` - (Optional) Runaway query control settings. When set, queries matching the criteria are automatically handled. This is the body of TiDB's `QUERY_LIMIT=(...)` clause. Supported TiDB criteria include `EXEC_ELAPSED='<duration>'`, `PROCESSED_KEYS=<count>`, and `RU=<count>`. Supported actions include `DRYRUN`, `COOLDOWN`, `KILL`, and, in TiDB v8.4.0 and later including v8.5.x, `SWITCH_GROUP(<resource_group>)`. The `WATCH` clause can use `EXACT`, `SIMILAR`, or `PLAN` with an optional `DURATION='<duration>'`. When empty (default), no query limit is applied.
 * `background` - (Optional, Computed) Raw body for TiDB's `BACKGROUND=(...)` resource group clause. TiDB currently supports this only on the `default` resource group. Use `NULL` to emit `BACKGROUND=NULL`.
 

--- a/docs/resources/ti_resource_group.md
+++ b/docs/resources/ti_resource_group.md
@@ -47,6 +47,17 @@ resource "mysql_ti_resource_group" "oltp" {
 }
 ```
 
+### Resource group with v8.5 runaway query controls
+
+```hcl
+resource "mysql_ti_resource_group" "oltp_guardrail" {
+  name           = "oltp_guardrail"
+  resource_units = 2000
+  priority       = "high"
+  query_limit    = "PROCESSED_KEYS=1000000, RU=2000, ACTION=SWITCH_GROUP(rg_quarantine), WATCH=PLAN DURATION='30m'"
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -55,7 +66,7 @@ The following arguments are supported:
 * `resource_units` - (Required) The number of Request Units per second (RU_PER_SEC) allocated to this resource group. This controls the throughput capacity. When reading existing TiDB resource groups, the provider maps TiDB's `UNLIMITED` value to `2147483647`.
 * `priority` - (Optional) The priority level of the resource group. Must be one of `high`, `medium`, or `low`. Defaults to `medium`.
 * `burstable` - (Optional) Whether the resource group can burst beyond its allocated RU_PER_SEC when there is spare capacity. Defaults to `false`.
-* `query_limit` - (Optional) Runaway query control settings. When set, queries matching the criteria are automatically handled. Format: `EXEC_ELAPSED='<duration>', ACTION=<KILL|COOLDOWN|DRYRUN>, WATCH=<EXACT|SIMILAR|PLAN> DURATION='<duration>'`. When empty (default), no query limit is applied.
+* `query_limit` - (Optional) Runaway query control settings. When set, queries matching the criteria are automatically handled. This is the body of TiDB's `QUERY_LIMIT=(...)` clause. Supported TiDB criteria include `EXEC_ELAPSED='<duration>'`, `PROCESSED_KEYS=<count>`, and `RU=<count>`. Supported actions include `DRYRUN`, `COOLDOWN`, `KILL`, and, in TiDB v8.4.0 and later including v8.5.x, `SWITCH_GROUP(<resource_group>)`. The `WATCH` clause can use `EXACT`, `SIMILAR`, or `PLAN` with an optional `DURATION='<duration>'`. When empty (default), no query limit is applied.
 
 ## Attributes Reference
 

--- a/docs/resources/ti_resource_group_user_assignment.md
+++ b/docs/resources/ti_resource_group_user_assignment.md
@@ -8,7 +8,7 @@ description: |-
 
 # mysql\_ti\_resource\_group\_user\_assignment
 
-The `mysql_ti_resource_group_user_assignment` resource assigns a MySQL/TiDB user to a [TiDB resource group](https://docs.pingcap.com/tidb/stable/tidb-resource-control). This controls which resource group governs the user's query execution.
+The `mysql_ti_resource_group_user_assignment` resource assigns a MySQL/TiDB user to a [TiDB resource group](https://docs.pingcap.com/tidb/stable/tidb-resource-control-ru-groups/). This controls which resource group governs the user's query execution using TiDB's [`ALTER USER ... RESOURCE GROUP`](https://docs.pingcap.com/tidb/stable/sql-statement-alter-user/) syntax.
 
 ~> **Note:** This resource requires TiDB v7.5.0 or later.
 
@@ -34,6 +34,7 @@ resource "mysql_ti_resource_group" "analytics" {
 
 resource "mysql_ti_resource_group_user_assignment" "analytics_user" {
   user           = mysql_user.analytics_user.user
+  host           = mysql_user.analytics_user.host
   resource_group = mysql_ti_resource_group.analytics.name
 }
 ```
@@ -43,6 +44,7 @@ resource "mysql_ti_resource_group_user_assignment" "analytics_user" {
 The following arguments are supported:
 
 * `user` - (Required, ForceNew) The name of the user to assign to the resource group. The user must already exist. Changing this forces a new resource.
+* `host` - (Optional, ForceNew) Host part of the TiDB user account. When omitted, the provider preserves the older username-only behavior.
 * `resource_group` - (Required) The name of the resource group to assign the user to. Can be updated to reassign the user to a different group.
 
 ## Attributes Reference
@@ -54,5 +56,5 @@ The following arguments are supported:
 User resource group assignments can be imported using the username.
 
 ```shell
-terraform import mysql_ti_resource_group_user_assignment.example analytics_user
+terraform import mysql_ti_resource_group_user_assignment.example analytics_user@%
 ```

--- a/docs/resources/user.md
+++ b/docs/resources/user.md
@@ -11,6 +11,8 @@ description: |-
 The ``mysql_user`` resource creates and manages a user on a MySQL
 server.
 
+For TiDB-specific user syntax, this resource also supports options documented in TiDB's [`CREATE USER`](https://docs.pingcap.com/tidb/stable/sql-statement-create-user/) and [`ALTER USER`](https://docs.pingcap.com/tidb/stable/sql-statement-alter-user/) statements, including resource group assignment and password lifecycle controls.
+
 ~> **Note:** The password for the user is provided in plain text, and is
 obscured by an unsalted hash in the state
 [Read more about sensitive data in state](https://www.terraform.io/language/state/sensitive-data).
@@ -60,6 +62,26 @@ resource "mysql_user" "aadupn" {
 }
 ```
 
+## Example Usage with TiDB Resource Controls
+
+```hcl
+resource "mysql_user" "app" {
+  user                    = "app"
+  host                    = "%"
+  plaintext_password      = "correct-horse-battery-staple"
+  resource_group          = "app_rg"
+  max_user_connections    = 20
+  account_locked          = false
+  comment                 = "application user"
+  attribute_json          = jsonencode({ team = "platform" })
+  password_expire         = "interval 90 day"
+  password_history        = "5"
+  password_reuse_interval = "30 day"
+  failed_login_attempts   = 3
+  password_lock_time      = "unbounded"
+}
+```
+
 ~> **Note on Azure Database for MySQL Single Server resource:** If you want to use this for `service_principal` with older Azure Database for MySQL Single Server resource, you need to set param `aad_auth_validate_oids_in_tenant` to `OFF` in provider configuration. For more details see [this issue](https://github.com/petoju/terraform-provider-mysql/issues/79).
 
 ## Argument Reference
@@ -75,6 +97,16 @@ The following arguments are supported:
 * `aad_identity` - (Optional) Required when `auth_plugin` is `aad_auth`. This should be block containing `type` and `identity`. `type` can be one of `user`, `group` and `service_principal`. `identity` then should containt either UPN of user, name of group or Client ID of service principal.
 * `retain_old_password` - (Optional) When `true`, the old password is retained when changing the password. Defaults to `false`. This use MySQL Dual Password Support feature and requires MySQL version 8.0.14 or newer. See [MySQL Dual Password documentation](https://dev.mysql.com/doc/refman/8.0/en/password-management.html#dual-passwords) for more.
 * `tls_option` - (Optional) An TLS-Option for the `CREATE USER` or `ALTER USER` statement. The value is suffixed to `REQUIRE`. A value of 'SSL' will generate a `CREATE USER ... REQUIRE SSL` statement. See the [MYSQL `CREATE USER` documentation](https://dev.mysql.com/doc/refman/5.7/en/create-user.html) for more. Ignored if MySQL version is under 5.7.0.
+* `resource_group` - (Optional, Computed, TiDB) Assigns the user to a TiDB resource group using `CREATE/ALTER USER ... RESOURCE GROUP`.
+* `max_user_connections` - (Optional, Computed) Sets `WITH MAX_USER_CONNECTIONS`.
+* `account_locked` - (Optional, Computed) Sets `ACCOUNT LOCK` or `ACCOUNT UNLOCK`.
+* `comment` - (Optional, Computed, TiDB) Sets the TiDB user `COMMENT` value.
+* `attribute_json` - (Optional, Computed, TiDB) Sets the TiDB user `ATTRIBUTE` JSON value.
+* `password_expire` - (Optional, Computed) Raw value for `PASSWORD EXPIRE`, such as `default`, `never`, or `interval 90 day`.
+* `password_history` - (Optional, Computed) Raw value for `PASSWORD HISTORY`, such as `default` or `5`.
+* `password_reuse_interval` - (Optional, Computed) Raw value for `PASSWORD REUSE INTERVAL`, such as `default` or `30 day`.
+* `failed_login_attempts` - (Optional, Computed) Sets `FAILED_LOGIN_ATTEMPTS`.
+* `password_lock_time` - (Optional, Computed) Raw value for `PASSWORD_LOCK_TIME`, such as `2` or `unbounded`.
 
 [ref-auth-plugins]: https://dev.mysql.com/doc/refman/5.7/en/authentication-plugins.html
 

--- a/mysql/data_source_ti_placement_labels.go
+++ b/mysql/data_source_ti_placement_labels.go
@@ -1,0 +1,84 @@
+package mysql
+
+import (
+	"context"
+	"encoding/json"
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func dataSourceTiPlacementLabels() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: ShowTiPlacementLabels,
+		Schema: map[string]*schema.Schema{
+			"labels": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"key": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"values": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func ShowTiPlacementLabels(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	db, err := getDatabaseFromMeta(ctx, meta)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	// TiDB extension documented at:
+	// https://docs.pingcap.com/tidb/stable/sql-statement-show-placement-labels/.
+	sql := "SHOW PLACEMENT LABELS"
+	log.Printf("[DEBUG] SQL: %s", sql)
+
+	rows, err := db.QueryContext(ctx, sql)
+	if err != nil {
+		return diag.Errorf("failed querying TiDB placement labels: %v", err)
+	}
+	defer rows.Close()
+
+	labels := []map[string]interface{}{}
+	for rows.Next() {
+		var key string
+		var rawValues string
+		if err := rows.Scan(&key, &rawValues); err != nil {
+			return diag.Errorf("failed scanning TiDB placement labels: %v", err)
+		}
+
+		values := []string{}
+		if err := json.Unmarshal([]byte(rawValues), &values); err != nil {
+			values = append(values, rawValues)
+		}
+
+		labels = append(labels, map[string]interface{}{
+			"key":    key,
+			"values": values,
+		})
+	}
+	if err := rows.Err(); err != nil {
+		return diag.Errorf("failed reading TiDB placement labels: %v", err)
+	}
+
+	if err := d.Set("labels", labels); err != nil {
+		return diag.Errorf("failed setting labels field: %v", err)
+	}
+
+	d.SetId(id.UniqueId())
+
+	return nil
+}

--- a/mysql/provider.go
+++ b/mysql/provider.go
@@ -241,8 +241,9 @@ func Provider() *schema.Provider {
 		},
 
 		DataSourcesMap: map[string]*schema.Resource{
-			"mysql_databases": dataSourceDatabases(),
-			"mysql_tables":    dataSourceTables(),
+			"mysql_databases":           dataSourceDatabases(),
+			"mysql_tables":              dataSourceTables(),
+			"mysql_ti_placement_labels": dataSourceTiPlacementLabels(),
 		},
 
 		ResourcesMap: map[string]*schema.Resource{
@@ -257,6 +258,7 @@ func Provider() *schema.Provider {
 			"mysql_ti_resource_group": resourceTiResourceGroup(),
 			"mysql_ti_resource_group_user_assignment": resourceTiResourceGroupUserAssignment(),
 			"mysql_ti_placement_policy":               resourceTiPlacementPolicy(),
+			"mysql_ti_placement_range_policy":         resourceTiPlacementRangePolicy(),
 			"mysql_rds_config":                        resourceRDSConfig(),
 			"mysql_default_roles":                     resourceDefaultRoles(),
 		},

--- a/mysql/resource_global_variable.go
+++ b/mysql/resource_global_variable.go
@@ -54,6 +54,8 @@ func CreateOrUpdateGlobalVariable(ctx context.Context, d *schema.ResourceData, m
 	name := d.Get("name").(string)
 	value := d.Get("value").(string)
 
+	// TiDB uses SET GLOBAL for persistent cluster variables too.
+	// See https://docs.pingcap.com/tidb/stable/sql-statement-set-variable/.
 	sqlBaseQuery := fmt.Sprintf("SET GLOBAL %s = ", quoteIdentifier(name))
 
 	// Detect number or string

--- a/mysql/resource_grant_unit_test.go
+++ b/mysql/resource_grant_unit_test.go
@@ -57,6 +57,31 @@ func TestParseGrantFromRowTableGrant(t *testing.T) {
 	}
 }
 
+func TestParseGrantFromRowTiDBResourceControlPrivileges(t *testing.T) {
+	grant, err := parseGrantFromRow("GRANT RESOURCE_GROUP_ADMIN, RESOURCE_GROUP_USER ON *.* TO 'ops'@'%'")
+	if err != nil {
+		t.Fatalf("parseGrantFromRow returned error: %s", err)
+	}
+
+	tableGrant, ok := grant.(*TablePrivilegeGrant)
+	if !ok {
+		t.Fatalf("parseGrantFromRow returned %T, want *TablePrivilegeGrant", grant)
+	}
+	if tableGrant.Database != "*" {
+		t.Fatalf("Database = %q, want *", tableGrant.Database)
+	}
+	if tableGrant.Table != "*" {
+		t.Fatalf("Table = %q, want *", tableGrant.Table)
+	}
+	wantPrivileges := []string{"RESOURCE_GROUP_ADMIN", "RESOURCE_GROUP_USER"}
+	if !reflect.DeepEqual(tableGrant.Privileges, wantPrivileges) {
+		t.Fatalf("Privileges = %#v, want %#v", tableGrant.Privileges, wantPrivileges)
+	}
+	if !tableGrant.UserOrRole.Equals(UserOrRole{Name: "ops", Host: "%"}) {
+		t.Fatalf("UserOrRole = %#v", tableGrant.UserOrRole)
+	}
+}
+
 func TestParseGrantFromRowProcedureGrant(t *testing.T) {
 	grant, err := parseGrantFromRow("GRANT EXECUTE ON PROCEDURE `app_db`.`rotate_keys` TO 'app'@'localhost'")
 	if err != nil {
@@ -159,6 +184,33 @@ func TestParseResourceFromDataTableGrant(t *testing.T) {
 		t.Fatalf("Privileges = %#v", tableGrant.Privileges)
 	}
 	if got := tableGrant.SQLGrantStatement(); got != "GRANT SELECT, UPDATE(C1, C2) ON `app_db`.`accounts` TO 'app'@'%' REQUIRE SSL WITH GRANT OPTION" {
+		t.Fatalf("SQLGrantStatement() = %q", got)
+	}
+}
+
+func TestParseResourceFromDataTiDBResourceControlPrivileges(t *testing.T) {
+	d := schema.TestResourceDataRaw(t, resourceGrant().Schema, map[string]interface{}{
+		"user":       "ops",
+		"host":       "%",
+		"database":   "*",
+		"table":      "*",
+		"privileges": []interface{}{"resource_group_user", "resource_group_admin"},
+	})
+
+	grant, diagErr := parseResourceFromData(d)
+	if diagErr.HasError() {
+		t.Fatalf("parseResourceFromData returned diagnostics: %s", diagErr[0].Summary)
+	}
+
+	tableGrant, ok := grant.(*TablePrivilegeGrant)
+	if !ok {
+		t.Fatalf("parseResourceFromData returned %T, want *TablePrivilegeGrant", grant)
+	}
+	wantPrivileges := []string{"RESOURCE_GROUP_ADMIN", "RESOURCE_GROUP_USER"}
+	if !reflect.DeepEqual(tableGrant.Privileges, wantPrivileges) {
+		t.Fatalf("Privileges = %#v, want %#v", tableGrant.Privileges, wantPrivileges)
+	}
+	if got := tableGrant.SQLGrantStatement(); got != "GRANT RESOURCE_GROUP_ADMIN, RESOURCE_GROUP_USER ON *.* TO 'ops'@'%'" {
 		t.Fatalf("SQLGrantStatement() = %q", got)
 	}
 }

--- a/mysql/resource_ti_placement_policy.go
+++ b/mysql/resource_ti_placement_policy.go
@@ -19,10 +19,17 @@ var UpdatePlacementPolicySQLPrefix = "ALTER PLACEMENT POLICY"
 var BracketsRegex = regexp.MustCompile("^\\[(.+)\\]$")
 
 type PlacementPolicy struct {
-	Name          string
-	PrimaryRegion string
-	Regions       []string
-	Constraints   []string
+	Name                string
+	PrimaryRegion       string
+	Regions             []string
+	Followers           int
+	Schedule            string
+	Learners            int
+	Constraints         []string
+	LeaderConstraints   []string
+	FollowerConstraints []string
+	LearnerConstraints  []string
+	SurvivalPreferences []string
 }
 
 func (pp *PlacementPolicy) buildSQLQuery(prefix string) string {
@@ -46,6 +53,18 @@ func (pp *PlacementPolicy) buildSQLQuery(prefix string) string {
 		query = append(query, regionsClause)
 	}
 
+	if pp.Followers > 0 {
+		query = append(query, fmt.Sprintf(`FOLLOWERS=%d`, pp.Followers))
+	}
+
+	if pp.Schedule != "" {
+		query = append(query, fmt.Sprintf(`SCHEDULE="%s"`, pp.Schedule))
+	}
+
+	if pp.Learners > 0 {
+		query = append(query, fmt.Sprintf(`LEARNERS=%d`, pp.Learners))
+	}
+
 	if len(pp.Constraints) > 0 {
 		constraintsClause := fmt.Sprintf(`CONSTRAINTS="[%s]"`, strings.Join(pp.Constraints, ","))
 		query = append(query, constraintsClause)
@@ -53,6 +72,22 @@ func (pp *PlacementPolicy) buildSQLQuery(prefix string) string {
 		// Allow for empty constraints to be set in order to represent a
 		// placement policy without constraints.
 		query = append(query, `CONSTRAINTS=""`)
+	}
+
+	if len(pp.LeaderConstraints) > 0 {
+		query = append(query, fmt.Sprintf(`LEADER_CONSTRAINTS="[%s]"`, strings.Join(pp.LeaderConstraints, ",")))
+	}
+
+	if len(pp.FollowerConstraints) > 0 {
+		query = append(query, fmt.Sprintf(`FOLLOWER_CONSTRAINTS="[%s]"`, strings.Join(pp.FollowerConstraints, ",")))
+	}
+
+	if len(pp.LearnerConstraints) > 0 {
+		query = append(query, fmt.Sprintf(`LEARNER_CONSTRAINTS="[%s]"`, strings.Join(pp.LearnerConstraints, ",")))
+	}
+
+	if len(pp.SurvivalPreferences) > 0 {
+		query = append(query, fmt.Sprintf(`SURVIVAL_PREFERENCES="[%s]"`, strings.Join(pp.SurvivalPreferences, ",")))
 	}
 
 	query = append(query, ";")
@@ -91,7 +126,54 @@ func resourceTiPlacementPolicy() *schema.Resource {
 				ForceNew: false,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
+			// TiDB placement options follow CREATE/ALTER PLACEMENT POLICY.
+			// See https://docs.pingcap.com/tidb/stable/sql-statement-create-placement-policy/.
+			"followers": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+				ForceNew: false,
+			},
+			"schedule": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: false,
+			},
+			"learners": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+				ForceNew: false,
+			},
 			"constraints": {
+				Type:     schema.TypeList,
+				Optional: true,
+				ForceNew: false,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"leader_constraints": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				ForceNew: false,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"follower_constraints": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				ForceNew: false,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"learner_constraints": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				ForceNew: false,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"survival_preferences": {
 				Type:     schema.TypeList,
 				Optional: true,
 				ForceNew: false,
@@ -204,40 +286,31 @@ func DeletePlacementPolicy(ctx context.Context, d *schema.ResourceData, meta int
 }
 
 func NewPlacementPolicyFromResourceData(d *schema.ResourceData) PlacementPolicy {
-	regionsAny := d.Get("regions").([]any)
-	constraintsAny := d.Get("constraints").([]any)
-	regions := []string{}
-	constraints := []string{}
-
-	for _, regionAny := range regionsAny {
-		regions = append(regions, regionAny.(string))
-	}
-
-	for _, constraintAny := range constraintsAny {
-		constraints = append(constraints, constraintAny.(string))
-	}
-
 	return PlacementPolicy{
-		Name:          d.Get("name").(string),
-		PrimaryRegion: d.Get("primary_region").(string),
-		Regions:       regions,
-		Constraints:   constraints,
+		Name:                d.Get("name").(string),
+		PrimaryRegion:       d.Get("primary_region").(string),
+		Regions:             resourceStringList(d, "regions"),
+		Followers:           d.Get("followers").(int),
+		Schedule:            d.Get("schedule").(string),
+		Learners:            d.Get("learners").(int),
+		Constraints:         resourceStringList(d, "constraints"),
+		LeaderConstraints:   resourceStringList(d, "leader_constraints"),
+		FollowerConstraints: resourceStringList(d, "follower_constraints"),
+		LearnerConstraints:  resourceStringList(d, "learner_constraints"),
+		SurvivalPreferences: resourceStringList(d, "survival_preferences"),
 	}
 }
 
 func getPlacementPolicyFromDB(db *sql.DB, name string) (*PlacementPolicy, error) {
 	pp := PlacementPolicy{Name: name}
 
-	query := `SELECT POLICY_NAME, PRIMARY_REGION, REGIONS, CONSTRAINTS FROM information_schema.placement_policies where POLICY_NAME = ?`
+	query := `SELECT * FROM information_schema.placement_policies where POLICY_NAME = ?`
 
 	ctx := context.Background()
 	tflog.SetField(ctx, "query", query)
 	tflog.Debug(ctx, "getPlacementPolicyFromDB")
 
-	var regionsHolder string
-	var constraintsHolder string
-
-	err := db.QueryRow(query, name).Scan(&pp.Name, &pp.PrimaryRegion, &regionsHolder, &constraintsHolder)
+	row, err := querySingleRowStringMap(db, query, name)
 	if errors.Is(err, sql.ErrNoRows) {
 		log.Printf("[DEBUG] placement policy doesn't exist (%s): %s", name, err)
 		return nil, nil
@@ -245,21 +318,72 @@ func getPlacementPolicyFromDB(db *sql.DB, name string) (*PlacementPolicy, error)
 		return nil, fmt.Errorf("error during get placement policy (%s): %s", name, err)
 	}
 
-	if regionsHolder != "" {
-		pp.Regions = strings.Split(regionsHolder, ",")
+	pp.Name = stringMapValue(row, "POLICY_NAME")
+	pp.PrimaryRegion = stringMapValue(row, "PRIMARY_REGION")
+	pp.Regions = splitCommaString(stringMapValue(row, "REGIONS"))
+	pp.Constraints = parsePlacementConstraintList(stringMapValue(row, "CONSTRAINTS"))
+	pp.LeaderConstraints = parsePlacementConstraintList(stringMapValue(row, "LEADER_CONSTRAINTS"))
+	pp.FollowerConstraints = parsePlacementConstraintList(stringMapValue(row, "FOLLOWER_CONSTRAINTS"))
+	pp.LearnerConstraints = parsePlacementConstraintList(stringMapValue(row, "LEARNER_CONSTRAINTS"))
+	pp.Schedule = stringMapValue(row, "SCHEDULE")
+
+	if followers, err := stringMapIntValue(row, "FOLLOWERS"); err == nil {
+		pp.Followers = followers
+	}
+	if learners, err := stringMapIntValue(row, "LEARNERS"); err == nil {
+		pp.Learners = learners
 	}
 
-	constraintMatches := BracketsRegex.FindStringSubmatch(constraintsHolder)
-	if len(constraintMatches) >= 2 {
-		pp.Constraints = strings.Split(constraintMatches[1], ",")
-	}
-
+	// SURVIVAL_PREFERENCES is accepted by CREATE/ALTER PLACEMENT POLICY, but
+	// PingCAP's documented information_schema.placement_policies columns do not expose it.
+	// See https://docs.pingcap.com/tidb/stable/information-schema-placement-policies/.
 	return &pp, nil
+}
+
+func splitCommaString(value string) []string {
+	if value == "" {
+		return nil
+	}
+
+	return strings.Split(value, ",")
+}
+
+func parsePlacementConstraintList(value string) []string {
+	constraintMatches := BracketsRegex.FindStringSubmatch(value)
+	if len(constraintMatches) >= 2 {
+		return strings.Split(constraintMatches[1], ",")
+	}
+
+	if value != "" {
+		return []string{value}
+	}
+
+	return nil
 }
 
 func setPlacementPolicyOnResourceData(pp PlacementPolicy, d *schema.ResourceData) {
 	d.Set("name", pp.Name)
 	d.Set("primary_region", pp.PrimaryRegion)
 	d.Set("regions", pp.Regions)
+	d.Set("followers", pp.Followers)
+	d.Set("schedule", pp.Schedule)
+	d.Set("learners", pp.Learners)
 	d.Set("constraints", pp.Constraints)
+	d.Set("leader_constraints", pp.LeaderConstraints)
+	d.Set("follower_constraints", pp.FollowerConstraints)
+	d.Set("learner_constraints", pp.LearnerConstraints)
+	if len(pp.SurvivalPreferences) > 0 {
+		d.Set("survival_preferences", pp.SurvivalPreferences)
+	}
+}
+
+func resourceStringList(d *schema.ResourceData, key string) []string {
+	valuesAny := d.Get(key).([]any)
+	values := []string{}
+
+	for _, valueAny := range valuesAny {
+		values = append(values, valueAny.(string))
+	}
+
+	return values
 }

--- a/mysql/resource_ti_placement_policy.go
+++ b/mysql/resource_ti_placement_policy.go
@@ -155,21 +155,18 @@ func resourceTiPlacementPolicy() *schema.Resource {
 			"leader_constraints": {
 				Type:     schema.TypeList,
 				Optional: true,
-				Computed: true,
 				ForceNew: false,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 			"follower_constraints": {
 				Type:     schema.TypeList,
 				Optional: true,
-				Computed: true,
 				ForceNew: false,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 			"learner_constraints": {
 				Type:     schema.TypeList,
 				Optional: true,
-				Computed: true,
 				ForceNew: false,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},

--- a/mysql/resource_ti_placement_policy_unit_test.go
+++ b/mysql/resource_ti_placement_policy_unit_test.go
@@ -32,12 +32,41 @@ func TestPlacementPolicyBuildSQLQueryEmptyConstraints(t *testing.T) {
 	}
 }
 
+func TestPlacementPolicyBuildSQLQueryExtendedTiDBOptions(t *testing.T) {
+	pp := PlacementPolicy{
+		Name:                "policy1",
+		PrimaryRegion:       "us-east-1",
+		Regions:             []string{"us-east-1", "us-west-2"},
+		Followers:           4,
+		Schedule:            "EVEN",
+		Learners:            1,
+		Constraints:         []string{"+disk=ssd"},
+		LeaderConstraints:   []string{"+zone=us-east-1a"},
+		FollowerConstraints: []string{"+zone=us-west-2a"},
+		LearnerConstraints:  []string{"+zone=us-west-2b"},
+		SurvivalPreferences: []string{"region", "zone"},
+	}
+
+	got := pp.buildSQLQuery(CreatePlacementPolicySQLPrefix)
+	want := `CREATE PLACEMENT POLICY IF NOT EXISTS policy1 PRIMARY_REGION="us-east-1" REGIONS="us-east-1,us-west-2" FOLLOWERS=4 SCHEDULE="EVEN" LEARNERS=1 CONSTRAINTS="[+disk=ssd]" LEADER_CONSTRAINTS="[+zone=us-east-1a]" FOLLOWER_CONSTRAINTS="[+zone=us-west-2a]" LEARNER_CONSTRAINTS="[+zone=us-west-2b]" SURVIVAL_PREFERENCES="[region,zone]" ;`
+	if got != want {
+		t.Fatalf("buildSQLQuery() = %q, want %q", got, want)
+	}
+}
+
 func TestPlacementPolicyResourceDataMapping(t *testing.T) {
 	d := schema.TestResourceDataRaw(t, resourceTiPlacementPolicy().Schema, map[string]interface{}{
-		"name":           "policy1",
-		"primary_region": "us-east-1",
-		"regions":        []interface{}{"us-east-1", "us-west-2"},
-		"constraints":    []interface{}{"+zone=us-east-1", "+disk=ssd"},
+		"name":                 "policy1",
+		"primary_region":       "us-east-1",
+		"regions":              []interface{}{"us-east-1", "us-west-2"},
+		"followers":            4,
+		"schedule":             "EVEN",
+		"learners":             1,
+		"constraints":          []interface{}{"+zone=us-east-1", "+disk=ssd"},
+		"leader_constraints":   []interface{}{"+zone=us-east-1a"},
+		"follower_constraints": []interface{}{"+zone=us-west-2a"},
+		"learner_constraints":  []interface{}{"+zone=us-west-2b"},
+		"survival_preferences": []interface{}{"region", "zone"},
 	})
 
 	pp := NewPlacementPolicyFromResourceData(d)
@@ -53,12 +82,40 @@ func TestPlacementPolicyResourceDataMapping(t *testing.T) {
 	if !reflect.DeepEqual(pp.Constraints, []string{"+zone=us-east-1", "+disk=ssd"}) {
 		t.Fatalf("Constraints = %#v", pp.Constraints)
 	}
+	if pp.Followers != 4 {
+		t.Fatalf("Followers = %d", pp.Followers)
+	}
+	if pp.Schedule != "EVEN" {
+		t.Fatalf("Schedule = %q", pp.Schedule)
+	}
+	if pp.Learners != 1 {
+		t.Fatalf("Learners = %d", pp.Learners)
+	}
+	if !reflect.DeepEqual(pp.LeaderConstraints, []string{"+zone=us-east-1a"}) {
+		t.Fatalf("LeaderConstraints = %#v", pp.LeaderConstraints)
+	}
+	if !reflect.DeepEqual(pp.FollowerConstraints, []string{"+zone=us-west-2a"}) {
+		t.Fatalf("FollowerConstraints = %#v", pp.FollowerConstraints)
+	}
+	if !reflect.DeepEqual(pp.LearnerConstraints, []string{"+zone=us-west-2b"}) {
+		t.Fatalf("LearnerConstraints = %#v", pp.LearnerConstraints)
+	}
+	if !reflect.DeepEqual(pp.SurvivalPreferences, []string{"region", "zone"}) {
+		t.Fatalf("SurvivalPreferences = %#v", pp.SurvivalPreferences)
+	}
 
 	setPlacementPolicyOnResourceData(PlacementPolicy{
-		Name:          "policy2",
-		PrimaryRegion: "us-west-2",
-		Regions:       []string{"us-west-2"},
-		Constraints:   []string{"+zone=us-west-2"},
+		Name:                "policy2",
+		PrimaryRegion:       "us-west-2",
+		Regions:             []string{"us-west-2"},
+		Followers:           2,
+		Schedule:            "MAJORITY_IN_PRIMARY",
+		Learners:            1,
+		Constraints:         []string{"+zone=us-west-2"},
+		LeaderConstraints:   []string{"+zone=us-west-2a"},
+		FollowerConstraints: []string{"+zone=us-west-2b"},
+		LearnerConstraints:  []string{"+zone=us-west-2c"},
+		SurvivalPreferences: []string{"zone"},
 	}, d)
 
 	if got := d.Get("name").(string); got != "policy2" {
@@ -72,6 +129,27 @@ func TestPlacementPolicyResourceDataMapping(t *testing.T) {
 	}
 	if got := expandStringList(d.Get("constraints").([]interface{})); !reflect.DeepEqual(got, []string{"+zone=us-west-2"}) {
 		t.Fatalf("resource data constraints = %#v", got)
+	}
+	if got := d.Get("followers").(int); got != 2 {
+		t.Fatalf("resource data followers = %d", got)
+	}
+	if got := d.Get("schedule").(string); got != "MAJORITY_IN_PRIMARY" {
+		t.Fatalf("resource data schedule = %q", got)
+	}
+	if got := d.Get("learners").(int); got != 1 {
+		t.Fatalf("resource data learners = %d", got)
+	}
+	if got := expandStringList(d.Get("leader_constraints").([]interface{})); !reflect.DeepEqual(got, []string{"+zone=us-west-2a"}) {
+		t.Fatalf("resource data leader_constraints = %#v", got)
+	}
+	if got := expandStringList(d.Get("follower_constraints").([]interface{})); !reflect.DeepEqual(got, []string{"+zone=us-west-2b"}) {
+		t.Fatalf("resource data follower_constraints = %#v", got)
+	}
+	if got := expandStringList(d.Get("learner_constraints").([]interface{})); !reflect.DeepEqual(got, []string{"+zone=us-west-2c"}) {
+		t.Fatalf("resource data learner_constraints = %#v", got)
+	}
+	if got := expandStringList(d.Get("survival_preferences").([]interface{})); !reflect.DeepEqual(got, []string{"zone"}) {
+		t.Fatalf("resource data survival_preferences = %#v", got)
 	}
 }
 

--- a/mysql/resource_ti_placement_range_policy.go
+++ b/mysql/resource_ti_placement_range_policy.go
@@ -1,0 +1,152 @@
+package mysql
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+func resourceTiPlacementRangePolicy() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: CreateOrUpdatePlacementRangePolicy,
+		ReadContext:   ReadPlacementRangePolicy,
+		UpdateContext: CreateOrUpdatePlacementRangePolicy,
+		DeleteContext: DeletePlacementRangePolicy,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+		Schema: map[string]*schema.Schema{
+			// TiDB ALTER RANGE supports only global and meta.
+			// See https://docs.pingcap.com/tidb/stable/sql-statement-alter-range/.
+			"range": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringInSlice([]string{"global", "meta"}, false),
+			},
+			"placement_policy": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"placement": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"scheduling_state": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func CreateOrUpdatePlacementRangePolicy(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	db, err := getDatabaseFromMeta(ctx, meta)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	rangeName := strings.ToLower(d.Get("range").(string))
+	placementPolicy := d.Get("placement_policy").(string)
+
+	query := fmt.Sprintf("ALTER RANGE %s PLACEMENT POLICY = %s", rangeName, quoteSQLString(placementPolicy))
+	log.Printf("[DEBUG] SQL: %s", query)
+
+	if _, err := db.ExecContext(ctx, query); err != nil {
+		return diag.Errorf("error setting TiDB placement policy (%s) on range (%s): %s", placementPolicy, rangeName, err)
+	}
+
+	d.SetId(rangeName)
+
+	return ReadPlacementRangePolicy(ctx, d, meta)
+}
+
+func ReadPlacementRangePolicy(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	db, err := getDatabaseFromMeta(ctx, meta)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	rangeName := strings.ToLower(d.Get("range").(string))
+	if rangeName == "" {
+		rangeName = strings.ToLower(d.Id())
+	}
+
+	placement, schedulingState, err := readPlacementRangePolicyFromDB(ctx, db, rangeName)
+	if err != nil {
+		return diag.Errorf("error reading TiDB placement range policy (%s): %s", rangeName, err)
+	}
+
+	d.Set("range", rangeName)
+	d.Set("placement", placement)
+	d.Set("scheduling_state", schedulingState)
+	d.SetId(rangeName)
+
+	return nil
+}
+
+func DeletePlacementRangePolicy(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	db, err := getDatabaseFromMeta(ctx, meta)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	rangeName := strings.ToLower(d.Get("range").(string))
+	query := fmt.Sprintf("ALTER RANGE %s PLACEMENT POLICY = %s", rangeName, quoteSQLString("default"))
+	log.Printf("[DEBUG] SQL: %s", query)
+
+	if _, err := db.ExecContext(ctx, query); err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return diag.Errorf("error resetting TiDB placement range policy (%s): %s", rangeName, err)
+	}
+
+	d.SetId("")
+
+	return nil
+}
+
+func readPlacementRangePolicyFromDB(ctx context.Context, db *sql.DB, rangeName string) (string, string, error) {
+	// TiDB SHOW PLACEMENT expands range policy placement instead of returning the policy name.
+	// See https://docs.pingcap.com/tidb/stable/placement-rules-in-sql/.
+	rows, err := db.QueryContext(ctx, "SHOW PLACEMENT")
+	if err != nil {
+		return "", "", err
+	}
+	defer rows.Close()
+
+	target := tiDBPlacementRangeTarget(rangeName)
+	for rows.Next() {
+		var rowTarget string
+		var placement string
+		var schedulingState string
+		if err := rows.Scan(&rowTarget, &placement, &schedulingState); err != nil {
+			return "", "", err
+		}
+
+		if rowTarget == target {
+			return placement, schedulingState, nil
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return "", "", err
+	}
+
+	return "", "", nil
+}
+
+func tiDBPlacementRangeTarget(rangeName string) string {
+	switch strings.ToLower(rangeName) {
+	case "global":
+		return "RANGE TiDB_GLOBAL"
+	case "meta":
+		return "RANGE TiDB_META"
+	default:
+		return "RANGE " + rangeName
+	}
+}

--- a/mysql/resource_ti_placement_range_policy_unit_test.go
+++ b/mysql/resource_ti_placement_range_policy_unit_test.go
@@ -1,0 +1,16 @@
+package mysql
+
+import "testing"
+
+func TestTiDBPlacementRangeTarget(t *testing.T) {
+	tests := map[string]string{
+		"global": "RANGE TiDB_GLOBAL",
+		"meta":   "RANGE TiDB_META",
+	}
+
+	for input, want := range tests {
+		if got := tiDBPlacementRangeTarget(input); got != want {
+			t.Fatalf("tiDBPlacementRangeTarget(%q) = %q, want %q", input, got, want)
+		}
+	}
+}

--- a/mysql/resource_ti_resource_group.go
+++ b/mysql/resource_ti_resource_group.go
@@ -22,16 +22,9 @@ type ResourceGroup struct {
 	ResourceUnits int
 	Priority      string
 	Burstable     bool
-	BurstableMode string
 	QueryLimit    string
 	Background    string
 }
-
-const (
-	ResourceGroupBurstableModeOff       = "off"
-	ResourceGroupBurstableModeModerated = "moderated"
-	ResourceGroupBurstableModeUnlimited = "unlimited"
-)
 
 var CreateResourceGroupSQLPrefix = "CREATE RESOURCE GROUP IF NOT EXISTS"
 var UpdateResourceGroupSQLPrefix = "ALTER RESOURCE GROUP"
@@ -63,10 +56,6 @@ func (rg *ResourceGroup) buildSQLQuery(prefix string) string {
 }
 
 func (rg *ResourceGroup) burstableSQLClause() string {
-	if rg.BurstableMode != "" {
-		return fmt.Sprintf(`BURSTABLE = %s`, strings.ToUpper(rg.BurstableMode))
-	}
-
 	return fmt.Sprintf(`BURSTABLE = %t`, rg.Burstable)
 }
 
@@ -119,15 +108,6 @@ func resourceTiResourceGroup() *schema.Resource {
 				Default:  DefaultResourceGroup.Burstable,
 				ForceNew: false,
 				Optional: true,
-			},
-			// TiDB v9.0 extends BURSTABLE from a boolean into OFF/MODERATED/UNLIMITED modes.
-			// See https://docs.pingcap.com/tidb/stable/sql-statement-create-resource-group/.
-			"burstable_mode": {
-				Type:         schema.TypeString,
-				ForceNew:     false,
-				Optional:     true,
-				Computed:     true,
-				ValidateFunc: validation.StringInSlice([]string{ResourceGroupBurstableModeOff, ResourceGroupBurstableModeModerated, ResourceGroupBurstableModeUnlimited}, false),
 			},
 			/*
 				QUERY_LIMIT=(EXEC_ELAPSED='60s', ACTION=KILL, WATCH=EXACT DURATION='10m')
@@ -257,8 +237,7 @@ func getResourceGroupFromDB(db *sql.DB, name string) (*ResourceGroup, error) {
 
 	/*
 		TiDB has changed information_schema.resource_groups across resource-control releases:
-		RU_PER_SEC can be numeric or UNLIMITED, BURSTABLE can be YES/NO or a v9 mode,
-		and BACKGROUND only exists on newer versions.
+		RU_PER_SEC can be numeric or UNLIMITED, and BACKGROUND only exists on newer versions.
 		See https://docs.pingcap.com/tidb/stable/sql-statement-create-resource-group/.
 	*/
 	query := `SELECT * FROM information_schema.resource_groups WHERE NAME = ?`
@@ -286,23 +265,17 @@ func getResourceGroupFromDB(db *sql.DB, name string) (*ResourceGroup, error) {
 	}
 	rg.ResourceUnits = resourceUnits
 
-	rg.Burstable, rg.BurstableMode = parseResourceGroupBurstable(stringMapValue(row, "BURSTABLE"))
+	rg.Burstable = parseResourceGroupBurstable(stringMapValue(row, "BURSTABLE"))
 
 	return &rg, nil
 }
 
 func NewResourceGroupFromResourceData(d *schema.ResourceData) ResourceGroup {
-	burstableMode := ""
-	if rawMode, ok := d.GetOk("burstable_mode"); ok {
-		burstableMode = strings.ToLower(rawMode.(string))
-	}
-
 	return ResourceGroup{
 		Name:          d.Get("name").(string),
 		ResourceUnits: d.Get("resource_units").(int),
 		Priority:      strings.ToUpper(d.Get("priority").(string)),
 		Burstable:     d.Get("burstable").(bool),
-		BurstableMode: burstableMode,
 		QueryLimit:    d.Get("query_limit").(string),
 		Background:    d.Get("background").(string),
 	}
@@ -313,7 +286,6 @@ func setResourceGroupOnResourceData(rg ResourceGroup, d *schema.ResourceData) {
 	d.Set("resource_units", rg.ResourceUnits)
 	d.Set("priority", rg.Priority)
 	d.Set("burstable", rg.Burstable)
-	d.Set("burstable_mode", rg.BurstableMode)
 	d.Set("query_limit", rg.QueryLimit)
 	d.Set("background", rg.Background)
 }
@@ -332,19 +304,13 @@ func parseResourceGroupResourceUnits(raw string) (int, error) {
 	return parsed, nil
 }
 
-func parseResourceGroupBurstable(raw string) (bool, string) {
+func parseResourceGroupBurstable(raw string) bool {
 	switch strings.ToUpper(strings.TrimSpace(raw)) {
 	case "YES", "TRUE", "1":
-		return true, ""
+		return true
 	case "NO", "FALSE", "0":
-		return false, ""
-	case "OFF":
-		return false, ResourceGroupBurstableModeOff
-	case "MODERATED":
-		return true, ResourceGroupBurstableModeModerated
-	case "UNLIMITED":
-		return true, ResourceGroupBurstableModeUnlimited
+		return false
 	default:
-		return false, ""
+		return false
 	}
 }

--- a/mysql/resource_ti_resource_group.go
+++ b/mysql/resource_ti_resource_group.go
@@ -6,6 +6,8 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"math"
+	"strconv"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -20,8 +22,16 @@ type ResourceGroup struct {
 	ResourceUnits int
 	Priority      string
 	Burstable     bool
+	BurstableMode string
 	QueryLimit    string
+	Background    string
 }
+
+const (
+	ResourceGroupBurstableModeOff       = "off"
+	ResourceGroupBurstableModeModerated = "moderated"
+	ResourceGroupBurstableModeUnlimited = "unlimited"
+)
 
 var CreateResourceGroupSQLPrefix = "CREATE RESOURCE GROUP IF NOT EXISTS"
 var UpdateResourceGroupSQLPrefix = "ALTER RESOURCE GROUP"
@@ -39,13 +49,33 @@ func (rg *ResourceGroup) buildSQLQuery(prefix string) string {
 		query = append(query, fmt.Sprintf(`QUERY_LIMIT=(%s)`, rg.QueryLimit))
 	}
 
-	query = append(query, fmt.Sprintf(`BURSTABLE = %t`, rg.Burstable))
+	if rg.Background != "" {
+		query = append(query, rg.backgroundSQLClause())
+	}
+
+	query = append(query, rg.burstableSQLClause())
 	query = append(query, ";")
 
 	ctx := context.TODO()
 	tflog.SetField(ctx, "sql", query)
 	tflog.Debug(ctx, `buildSQLQuery`)
 	return strings.Join(query, " ")
+}
+
+func (rg *ResourceGroup) burstableSQLClause() string {
+	if rg.BurstableMode != "" {
+		return fmt.Sprintf(`BURSTABLE = %s`, strings.ToUpper(rg.BurstableMode))
+	}
+
+	return fmt.Sprintf(`BURSTABLE = %t`, rg.Burstable)
+}
+
+func (rg *ResourceGroup) backgroundSQLClause() string {
+	if strings.EqualFold(strings.TrimSpace(rg.Background), "NULL") {
+		return "BACKGROUND=NULL"
+	}
+
+	return fmt.Sprintf(`BACKGROUND=(%s)`, rg.Background)
 }
 
 var DefaultResourceGroup = ResourceGroup{
@@ -90,6 +120,15 @@ func resourceTiResourceGroup() *schema.Resource {
 				ForceNew: false,
 				Optional: true,
 			},
+			// TiDB v9.0 extends BURSTABLE from a boolean into OFF/MODERATED/UNLIMITED modes.
+			// See https://docs.pingcap.com/tidb/stable/sql-statement-create-resource-group/.
+			"burstable_mode": {
+				Type:         schema.TypeString,
+				ForceNew:     false,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: validation.StringInSlice([]string{ResourceGroupBurstableModeOff, ResourceGroupBurstableModeModerated, ResourceGroupBurstableModeUnlimited}, false),
+			},
 			/*
 				QUERY_LIMIT=(EXEC_ELAPSED='60s', ACTION=KILL, WATCH=EXACT DURATION='10m')
 			*/
@@ -98,6 +137,14 @@ func resourceTiResourceGroup() *schema.Resource {
 				Default:  DefaultResourceGroup.QueryLimit,
 				ForceNew: false,
 				Optional: true,
+			},
+			// TiDB exposes BACKGROUND on RESOURCE GROUP for the default group only.
+			// See https://docs.pingcap.com/tidb/stable/tidb-resource-control-background-tasks/.
+			"background": {
+				Type:     schema.TypeString,
+				ForceNew: false,
+				Optional: true,
+				Computed: true,
 			},
 		},
 	}
@@ -209,18 +256,18 @@ func getResourceGroupFromDB(db *sql.DB, name string) (*ResourceGroup, error) {
 	rg := ResourceGroup{Name: name}
 
 	/*
-		Coerce types on SQL side into good types for golang
-		Burstable is a varchar(3) so we coerce to BOOLEAN
-		QUERY_LIMIT is nullable in DB, but we coerce to standard "empty" string type of ""
-		Lowercase priority for less configuration variability
+		TiDB has changed information_schema.resource_groups across resource-control releases:
+		RU_PER_SEC can be numeric or UNLIMITED, BURSTABLE can be YES/NO or a v9 mode,
+		and BACKGROUND only exists on newer versions.
+		See https://docs.pingcap.com/tidb/stable/sql-statement-create-resource-group/.
 	*/
-	query := `SELECT NAME, RU_PER_SEC, LOWER(PRIORITY), BURSTABLE = 'YES' as BURSTABLE, IFNULL(QUERY_LIMIT,"") FROM information_schema.resource_groups WHERE NAME = ?`
+	query := `SELECT * FROM information_schema.resource_groups WHERE NAME = ?`
 
 	ctx := context.Background()
 	tflog.SetField(ctx, "query", query)
 	tflog.Debug(ctx, "getResourceGroupFromDB")
 
-	err := db.QueryRow(query, name).Scan(&rg.Name, &rg.ResourceUnits, &rg.Priority, &rg.Burstable, &rg.QueryLimit)
+	row, err := querySingleRowStringMap(db, query, name)
 	if errors.Is(err, sql.ErrNoRows) {
 		log.Printf("[DEBUG] resource group doesn't exist (%s): %s", name, err)
 		return nil, nil
@@ -228,16 +275,36 @@ func getResourceGroupFromDB(db *sql.DB, name string) (*ResourceGroup, error) {
 		return nil, fmt.Errorf("error during get resource group (%s): %s", name, err)
 	}
 
+	rg.Name = stringMapValue(row, "NAME")
+	rg.Priority = strings.ToLower(stringMapValue(row, "PRIORITY"))
+	rg.QueryLimit = stringMapValue(row, "QUERY_LIMIT")
+	rg.Background = stringMapValue(row, "BACKGROUND")
+
+	resourceUnits, err := parseResourceGroupResourceUnits(stringMapValue(row, "RU_PER_SEC"))
+	if err != nil {
+		return nil, fmt.Errorf("error parsing resource group RU_PER_SEC (%s): %s", name, err)
+	}
+	rg.ResourceUnits = resourceUnits
+
+	rg.Burstable, rg.BurstableMode = parseResourceGroupBurstable(stringMapValue(row, "BURSTABLE"))
+
 	return &rg, nil
 }
 
 func NewResourceGroupFromResourceData(d *schema.ResourceData) ResourceGroup {
+	burstableMode := ""
+	if rawMode, ok := d.GetOk("burstable_mode"); ok {
+		burstableMode = strings.ToLower(rawMode.(string))
+	}
+
 	return ResourceGroup{
 		Name:          d.Get("name").(string),
 		ResourceUnits: d.Get("resource_units").(int),
 		Priority:      strings.ToUpper(d.Get("priority").(string)),
 		Burstable:     d.Get("burstable").(bool),
+		BurstableMode: burstableMode,
 		QueryLimit:    d.Get("query_limit").(string),
+		Background:    d.Get("background").(string),
 	}
 }
 
@@ -246,5 +313,36 @@ func setResourceGroupOnResourceData(rg ResourceGroup, d *schema.ResourceData) {
 	d.Set("resource_units", rg.ResourceUnits)
 	d.Set("priority", rg.Priority)
 	d.Set("burstable", rg.Burstable)
+	d.Set("burstable_mode", rg.BurstableMode)
 	d.Set("query_limit", rg.QueryLimit)
+	d.Set("background", rg.Background)
+}
+
+func parseResourceGroupResourceUnits(raw string) (int, error) {
+	value := strings.TrimSpace(raw)
+	if strings.EqualFold(value, "UNLIMITED") {
+		return math.MaxInt32, nil
+	}
+
+	parsed, err := strconv.Atoi(value)
+	if err != nil {
+		return 0, err
+	}
+
+	return parsed, nil
+}
+
+func parseResourceGroupBurstable(raw string) (bool, string) {
+	switch strings.ToUpper(strings.TrimSpace(raw)) {
+	case "YES", "TRUE", "1":
+		return true, ResourceGroupBurstableModeModerated
+	case "NO", "FALSE", "0", "OFF":
+		return false, ResourceGroupBurstableModeOff
+	case "MODERATED":
+		return true, ResourceGroupBurstableModeModerated
+	case "UNLIMITED":
+		return true, ResourceGroupBurstableModeUnlimited
+	default:
+		return false, ""
+	}
 }

--- a/mysql/resource_ti_resource_group.go
+++ b/mysql/resource_ti_resource_group.go
@@ -335,8 +335,10 @@ func parseResourceGroupResourceUnits(raw string) (int, error) {
 func parseResourceGroupBurstable(raw string) (bool, string) {
 	switch strings.ToUpper(strings.TrimSpace(raw)) {
 	case "YES", "TRUE", "1":
-		return true, ResourceGroupBurstableModeModerated
-	case "NO", "FALSE", "0", "OFF":
+		return true, ""
+	case "NO", "FALSE", "0":
+		return false, ""
+	case "OFF":
 		return false, ResourceGroupBurstableModeOff
 	case "MODERATED":
 		return true, ResourceGroupBurstableModeModerated

--- a/mysql/resource_ti_resource_group_unit_test.go
+++ b/mysql/resource_ti_resource_group_unit_test.go
@@ -72,6 +72,48 @@ func TestResourceGroupBuildSQLQueryRunawayQueryControls(t *testing.T) {
 	}
 }
 
+func TestResourceGroupBuildSQLQueryTiDB9BurstableModeAndBackground(t *testing.T) {
+	rg := ResourceGroup{
+		Name:          "default",
+		ResourceUnits: 2147483647,
+		Priority:      "MEDIUM",
+		BurstableMode: ResourceGroupBurstableModeUnlimited,
+		Background:    `TASK_TYPES='br,ddl', UTILIZATION_LIMIT=30`,
+	}
+
+	got := rg.buildSQLQuery(UpdateResourceGroupSQLPrefix)
+	want := "ALTER RESOURCE GROUP default RU_PER_SEC = 2147483647 PRIORITY = MEDIUM QUERY_LIMIT=NULL BACKGROUND=(TASK_TYPES='br,ddl', UTILIZATION_LIMIT=30) BURSTABLE = UNLIMITED ;"
+	if got != want {
+		t.Fatalf("buildSQLQuery() = %q, want %q", got, want)
+	}
+}
+
+func TestResourceGroupParsesTiDBResourceGroupReadValues(t *testing.T) {
+	resourceUnits, err := parseResourceGroupResourceUnits("UNLIMITED")
+	if err != nil {
+		t.Fatalf("parseResourceGroupResourceUnits() error = %v", err)
+	}
+	if resourceUnits != 2147483647 {
+		t.Fatalf("resourceUnits = %d, want 2147483647", resourceUnits)
+	}
+
+	burstable, mode := parseResourceGroupBurstable("UNLIMITED")
+	if !burstable {
+		t.Fatal("burstable = false, want true")
+	}
+	if mode != ResourceGroupBurstableModeUnlimited {
+		t.Fatalf("mode = %q, want %q", mode, ResourceGroupBurstableModeUnlimited)
+	}
+
+	burstable, mode = parseResourceGroupBurstable("OFF")
+	if burstable {
+		t.Fatal("burstable = true, want false")
+	}
+	if mode != ResourceGroupBurstableModeOff {
+		t.Fatalf("mode = %q, want %q", mode, ResourceGroupBurstableModeOff)
+	}
+}
+
 func TestResourceGroupResourceDataMapping(t *testing.T) {
 	d := schema.TestResourceDataRaw(t, resourceTiResourceGroup().Schema, map[string]interface{}{
 		"name":           "rg100",

--- a/mysql/resource_ti_resource_group_unit_test.go
+++ b/mysql/resource_ti_resource_group_unit_test.go
@@ -105,6 +105,14 @@ func TestResourceGroupParsesTiDBResourceGroupReadValues(t *testing.T) {
 		t.Fatalf("mode = %q, want %q", mode, ResourceGroupBurstableModeUnlimited)
 	}
 
+	burstable, mode = parseResourceGroupBurstable("YES")
+	if !burstable {
+		t.Fatal("legacy burstable = false, want true")
+	}
+	if mode != "" {
+		t.Fatalf("legacy mode = %q, want empty", mode)
+	}
+
 	burstable, mode = parseResourceGroupBurstable("OFF")
 	if burstable {
 		t.Fatal("burstable = true, want false")

--- a/mysql/resource_ti_resource_group_unit_test.go
+++ b/mysql/resource_ti_resource_group_unit_test.go
@@ -72,17 +72,17 @@ func TestResourceGroupBuildSQLQueryRunawayQueryControls(t *testing.T) {
 	}
 }
 
-func TestResourceGroupBuildSQLQueryTiDB9BurstableModeAndBackground(t *testing.T) {
+func TestResourceGroupBuildSQLQueryBackground(t *testing.T) {
 	rg := ResourceGroup{
 		Name:          "default",
 		ResourceUnits: 2147483647,
 		Priority:      "MEDIUM",
-		BurstableMode: ResourceGroupBurstableModeUnlimited,
+		Burstable:     true,
 		Background:    `TASK_TYPES='br,ddl', UTILIZATION_LIMIT=30`,
 	}
 
 	got := rg.buildSQLQuery(UpdateResourceGroupSQLPrefix)
-	want := "ALTER RESOURCE GROUP default RU_PER_SEC = 2147483647 PRIORITY = MEDIUM QUERY_LIMIT=NULL BACKGROUND=(TASK_TYPES='br,ddl', UTILIZATION_LIMIT=30) BURSTABLE = UNLIMITED ;"
+	want := "ALTER RESOURCE GROUP default RU_PER_SEC = 2147483647 PRIORITY = MEDIUM QUERY_LIMIT=NULL BACKGROUND=(TASK_TYPES='br,ddl', UTILIZATION_LIMIT=30) BURSTABLE = true ;"
 	if got != want {
 		t.Fatalf("buildSQLQuery() = %q, want %q", got, want)
 	}
@@ -97,28 +97,14 @@ func TestResourceGroupParsesTiDBResourceGroupReadValues(t *testing.T) {
 		t.Fatalf("resourceUnits = %d, want 2147483647", resourceUnits)
 	}
 
-	burstable, mode := parseResourceGroupBurstable("UNLIMITED")
+	burstable := parseResourceGroupBurstable("YES")
 	if !burstable {
-		t.Fatal("burstable = false, want true")
-	}
-	if mode != ResourceGroupBurstableModeUnlimited {
-		t.Fatalf("mode = %q, want %q", mode, ResourceGroupBurstableModeUnlimited)
+		t.Fatal("burstable = false, want true for YES")
 	}
 
-	burstable, mode = parseResourceGroupBurstable("YES")
-	if !burstable {
-		t.Fatal("legacy burstable = false, want true")
-	}
-	if mode != "" {
-		t.Fatalf("legacy mode = %q, want empty", mode)
-	}
-
-	burstable, mode = parseResourceGroupBurstable("OFF")
+	burstable = parseResourceGroupBurstable("NO")
 	if burstable {
-		t.Fatal("burstable = true, want false")
-	}
-	if mode != ResourceGroupBurstableModeOff {
-		t.Fatalf("mode = %q, want %q", mode, ResourceGroupBurstableModeOff)
+		t.Fatal("burstable = true, want false for NO")
 	}
 }
 

--- a/mysql/resource_ti_resource_group_unit_test.go
+++ b/mysql/resource_ti_resource_group_unit_test.go
@@ -37,6 +37,41 @@ func TestResourceGroupBuildSQLQueryEmptyQueryLimit(t *testing.T) {
 	}
 }
 
+func TestResourceGroupBuildSQLQueryRunawayQueryControls(t *testing.T) {
+	tests := []struct {
+		name       string
+		queryLimit string
+		want       string
+	}{
+		{
+			name:       "dry run elapsed time",
+			queryLimit: "EXEC_ELAPSED='5s', ACTION=DRYRUN",
+			want:       "ALTER RESOURCE GROUP rg_runaway RU_PER_SEC = 5000 PRIORITY = MEDIUM QUERY_LIMIT=(EXEC_ELAPSED='5s', ACTION=DRYRUN) BURSTABLE = false ;",
+		},
+		{
+			name:       "processed keys and ru switch group",
+			queryLimit: "PROCESSED_KEYS=1000000, RU=2000, ACTION=SWITCH_GROUP(rg_quarantine), WATCH=PLAN DURATION='30m'",
+			want:       "ALTER RESOURCE GROUP rg_runaway RU_PER_SEC = 5000 PRIORITY = MEDIUM QUERY_LIMIT=(PROCESSED_KEYS=1000000, RU=2000, ACTION=SWITCH_GROUP(rg_quarantine), WATCH=PLAN DURATION='30m') BURSTABLE = false ;",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rg := ResourceGroup{
+				Name:          "rg_runaway",
+				ResourceUnits: 5000,
+				Priority:      "MEDIUM",
+				Burstable:     false,
+				QueryLimit:    tt.queryLimit,
+			}
+
+			if got := rg.buildSQLQuery(UpdateResourceGroupSQLPrefix); got != tt.want {
+				t.Fatalf("buildSQLQuery() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestResourceGroupResourceDataMapping(t *testing.T) {
 	d := schema.TestResourceDataRaw(t, resourceTiResourceGroup().Schema, map[string]interface{}{
 		"name":           "rg100",

--- a/mysql/resource_ti_resource_group_user_assignment.go
+++ b/mysql/resource_ti_resource_group_user_assignment.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 
@@ -27,6 +28,13 @@ func resourceTiResourceGroupUserAssignment() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 			},
+			// TiDB ALTER USER accepts an optional user host just like CREATE USER.
+			// See https://docs.pingcap.com/tidb/stable/sql-statement-alter-user/.
+			"host": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
 			"resource_group": {
 				Type:     schema.TypeString,
 				Required: true,
@@ -43,12 +51,13 @@ func CreateOrUpdateResourceGroupUser(ctx context.Context, d *schema.ResourceData
 
 	// TODO: should this be the d.Id()?
 	user := d.Get("user").(string)
+	host := d.Get("host").(string)
 	resourceGroup := d.Get("resource_group").(string)
 
 	var warnLevel, warnMessage string
 	var warnCode int = 0
 
-	currentUser, _, err := readUserFromDB(db, user)
+	currentUser, _, err := readUserFromDB(db, user, host)
 	if err != nil {
 		d.SetId("")
 		return diag.Errorf(`error during get user (%s): %s`, user, err)
@@ -59,7 +68,7 @@ func CreateOrUpdateResourceGroupUser(ctx context.Context, d *schema.ResourceData
 		return diag.Errorf(`must create user first before assigning to resource group | getting user %s | error %s`, currentUser, err)
 	}
 
-	sql := fmt.Sprintf("ALTER USER `%s` RESOURCE GROUP `%s`", user, resourceGroup)
+	sql := fmt.Sprintf("ALTER USER %s RESOURCE GROUP %s", formatTiDBUserAccount(user, host), quoteIdentifier(resourceGroup))
 	log.Printf("[DEBUG] SQL: %s\n", sql)
 
 	_, err = db.ExecContext(ctx, sql)
@@ -74,7 +83,7 @@ func CreateOrUpdateResourceGroupUser(ctx context.Context, d *schema.ResourceData
 		return diag.Errorf("error setting value: %s -> %s Error: %s", user, resourceGroup, warnMessage)
 	}
 
-	d.SetId(user)
+	d.SetId(formatTiDBResourceGroupUserAssignmentID(user, host))
 	return nil
 }
 
@@ -86,7 +95,8 @@ func ReadResourceGroupUser(ctx context.Context, d *schema.ResourceData, meta int
 		return diag.FromErr(err)
 	}
 
-	user, resourceGroup, err = readUserFromDB(db, d.Id())
+	userID, hostID := parseTiDBResourceGroupUserAssignmentID(d.Id())
+	user, resourceGroup, err = readUserFromDB(db, userID, hostID)
 	if err != nil {
 		d.SetId("")
 		return diag.Errorf(`error getting user %s`, err)
@@ -100,6 +110,7 @@ func ReadResourceGroupUser(ctx context.Context, d *schema.ResourceData, meta int
 	}
 
 	d.Set("user", user)
+	d.Set("host", hostID)
 	d.Set("resource_group", resourceGroup)
 
 	return nil
@@ -107,13 +118,14 @@ func ReadResourceGroupUser(ctx context.Context, d *schema.ResourceData, meta int
 
 func DeleteResourceGroupUser(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	user := d.Get("user").(string)
+	host := d.Get("host").(string)
 
 	db, err := getDatabaseFromMeta(ctx, meta)
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
-	deleteQuery := fmt.Sprintf("ALTER USER `%s` RESOURCE GROUP `default`", user)
+	deleteQuery := fmt.Sprintf("ALTER USER %s RESOURCE GROUP `default`", formatTiDBUserAccount(user, host))
 	_, err = db.Exec(deleteQuery)
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		return diag.Errorf("error during drop resource group (%s): %s", d.Id(), err)
@@ -123,9 +135,15 @@ func DeleteResourceGroupUser(ctx context.Context, d *schema.ResourceData, meta i
 	return nil
 }
 
-func readUserFromDB(db *sql.DB, name string) (string, string, error) {
+func readUserFromDB(db *sql.DB, name string, host string) (string, string, error) {
 	selectUsersQuery := `SELECT USER, JSON_UNQUOTE(IFNULL(JSON_EXTRACT(User_attributes, "$.resource_group"), "")) as resource_group FROM mysql.user WHERE USER = ?`
-	row := db.QueryRow(selectUsersQuery, name)
+	args := []interface{}{name}
+	if host != "" {
+		selectUsersQuery += ` AND HOST = ?`
+		args = append(args, host)
+	}
+
+	row := db.QueryRow(selectUsersQuery, args...)
 
 	var user, resourceGroup string
 
@@ -138,4 +156,29 @@ func readUserFromDB(db *sql.DB, name string) (string, string, error) {
 	}
 
 	return user, resourceGroup, nil
+}
+
+func formatTiDBUserAccount(user string, host string) string {
+	if host == "" {
+		return quoteIdentifier(user)
+	}
+
+	return fmt.Sprintf("%s@%s", quoteIdentifier(user), quoteIdentifier(host))
+}
+
+func formatTiDBResourceGroupUserAssignmentID(user string, host string) string {
+	if host == "" {
+		return user
+	}
+
+	return user + "@" + host
+}
+
+func parseTiDBResourceGroupUserAssignmentID(id string) (string, string) {
+	parts := strings.SplitN(id, "@", 2)
+	if len(parts) != 2 {
+		return id, ""
+	}
+
+	return parts[0], parts[1]
 }

--- a/mysql/resource_ti_resource_group_user_assignment_test.go
+++ b/mysql/resource_ti_resource_group_user_assignment_test.go
@@ -45,7 +45,7 @@ func testAccResourceGroupUserAssignmentExists(username string, resourceGroupName
 			return err
 		}
 
-		user, resourceGroup, err := readUserFromDB(db, username)
+		user, resourceGroup, err := readUserFromDB(db, username, "%")
 		if err != nil {
 			return err
 		}
@@ -83,6 +83,7 @@ resource "mysql_ti_resource_group" "test" {
 
 resource "mysql_ti_resource_group_user_assignment" "test" {
 	user = "${mysql_user.test.user}"
+	host = "${mysql_user.test.host}"
 	resource_group = "${mysql_ti_resource_group.test.name}"
 }
 `, varUsername, varResourceGroupName, varResourceUnits, varQueryLimit)

--- a/mysql/resource_user.go
+++ b/mysql/resource_user.go
@@ -106,6 +106,79 @@ func resourceUser() *schema.Resource {
 				Type:     schema.TypeBool,
 				Optional: true,
 			},
+
+			// TiDB supports binding users to resource groups directly in CREATE/ALTER USER.
+			// See https://docs.pingcap.com/tidb/stable/sql-statement-create-user/.
+			"resource_group": {
+				Type:             schema.TypeString,
+				Optional:         true,
+				Computed:         true,
+				DiffSuppressFunc: NewEmptyStringSuppressFunc,
+			},
+
+			// TiDB CREATE/ALTER USER supports MAX_USER_CONNECTIONS, account locking,
+			// comments, JSON attributes, and password lifecycle options.
+			// See https://docs.pingcap.com/tidb/stable/sql-statement-alter-user/.
+			"max_user_connections": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+			},
+
+			"account_locked": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Computed: true,
+			},
+
+			"comment": {
+				Type:             schema.TypeString,
+				Optional:         true,
+				Computed:         true,
+				DiffSuppressFunc: NewEmptyStringSuppressFunc,
+			},
+
+			"attribute_json": {
+				Type:             schema.TypeString,
+				Optional:         true,
+				Computed:         true,
+				ValidateFunc:     validation.StringIsJSON,
+				DiffSuppressFunc: NewEmptyStringSuppressFunc,
+			},
+
+			"password_expire": {
+				Type:             schema.TypeString,
+				Optional:         true,
+				Computed:         true,
+				DiffSuppressFunc: NewEmptyStringSuppressFunc,
+			},
+
+			"password_history": {
+				Type:             schema.TypeString,
+				Optional:         true,
+				Computed:         true,
+				DiffSuppressFunc: NewEmptyStringSuppressFunc,
+			},
+
+			"password_reuse_interval": {
+				Type:             schema.TypeString,
+				Optional:         true,
+				Computed:         true,
+				DiffSuppressFunc: NewEmptyStringSuppressFunc,
+			},
+
+			"failed_login_attempts": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+			},
+
+			"password_lock_time": {
+				Type:             schema.TypeString,
+				Optional:         true,
+				Computed:         true,
+				DiffSuppressFunc: NewEmptyStringSuppressFunc,
+			},
 		},
 	}
 }
@@ -218,6 +291,10 @@ func CreateUser(ctx context.Context, d *schema.ResourceData, meta interface{}) d
 		if err != nil {
 			return diag.Errorf("cannot use retain_current_password: %v", err)
 		}
+	}
+
+	if createObj == "USER" {
+		stmtSQL = appendTiDBUserOptionClauses(stmtSQL, buildTiDBUserOptionClauses(d, false))
 	}
 
 	log.Println("[DEBUG] Executing statement:", stmtSQL)
@@ -336,6 +413,22 @@ func UpdateUser(ctx context.Context, d *schema.ResourceData, meta interface{}) d
 		}
 	}
 
+	if tiDBUserOptionsChanged(d) {
+		clauses := buildTiDBUserOptionClauses(d, true)
+		if len(clauses) > 0 {
+			stmtSQL := fmt.Sprintf("ALTER USER '%s'@'%s' %s",
+				d.Get("user").(string),
+				d.Get("host").(string),
+				strings.Join(clauses, " "))
+
+			log.Println("[DEBUG] Executing query:", stmtSQL)
+			_, err := db.ExecContext(ctx, stmtSQL)
+			if err != nil {
+				return diag.Errorf("failed setting TiDB user options: %v", err)
+			}
+		}
+	}
+
 	return nil
 }
 
@@ -407,6 +500,7 @@ func ReadUser(ctx context.Context, d *schema.ResourceData, meta interface{}) dia
 			} else {
 				d.Set("auth_string_hashed", m[4])
 			}
+			setTiDBUserOptionsFromCreateStatement(createUserStmt, d)
 			return nil
 		}
 
@@ -487,4 +581,151 @@ func NewEmptyStringSuppressFunc(k, old, new string, d *schema.ResourceData) bool
 	}
 
 	return false
+}
+
+func appendTiDBUserOptionClauses(stmtSQL string, clauses []string) string {
+	if len(clauses) == 0 {
+		return stmtSQL
+	}
+
+	return stmtSQL + " " + strings.Join(clauses, " ")
+}
+
+func tiDBUserOptionsChanged(d *schema.ResourceData) bool {
+	for _, key := range []string{
+		"resource_group",
+		"max_user_connections",
+		"account_locked",
+		"comment",
+		"attribute_json",
+		"password_expire",
+		"password_history",
+		"password_reuse_interval",
+		"failed_login_attempts",
+		"password_lock_time",
+	} {
+		if d.HasChange(key) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func buildTiDBUserOptionClauses(d *schema.ResourceData, includeClears bool) []string {
+	clauses := []string{}
+
+	if value, ok := d.GetOk("max_user_connections"); ok {
+		clauses = append(clauses, fmt.Sprintf("WITH MAX_USER_CONNECTIONS %d", value.(int)))
+	} else if includeClears && d.HasChange("max_user_connections") {
+		clauses = append(clauses, "WITH MAX_USER_CONNECTIONS 0")
+	}
+
+	if value, ok := d.GetOk("password_expire"); ok {
+		clauses = append(clauses, "PASSWORD EXPIRE "+strings.ToUpper(value.(string)))
+	}
+
+	if value, ok := d.GetOk("password_history"); ok {
+		clauses = append(clauses, "PASSWORD HISTORY "+strings.ToUpper(value.(string)))
+	}
+
+	if value, ok := d.GetOk("password_reuse_interval"); ok {
+		clauses = append(clauses, "PASSWORD REUSE INTERVAL "+strings.ToUpper(value.(string)))
+	}
+
+	if value, ok := d.GetOk("failed_login_attempts"); ok {
+		clauses = append(clauses, fmt.Sprintf("FAILED_LOGIN_ATTEMPTS %d", value.(int)))
+	}
+
+	if value, ok := d.GetOk("password_lock_time"); ok {
+		clauses = append(clauses, "PASSWORD_LOCK_TIME "+strings.ToUpper(value.(string)))
+	}
+
+	if value, ok := d.GetOkExists("account_locked"); ok {
+		if value.(bool) {
+			clauses = append(clauses, "ACCOUNT LOCK")
+		} else {
+			clauses = append(clauses, "ACCOUNT UNLOCK")
+		}
+	}
+
+	if value, ok := d.GetOk("comment"); ok {
+		clauses = append(clauses, "COMMENT "+quoteSQLString(value.(string)))
+	} else if includeClears && d.HasChange("comment") {
+		clauses = append(clauses, "COMMENT ''")
+	}
+
+	if value, ok := d.GetOk("attribute_json"); ok {
+		clauses = append(clauses, "ATTRIBUTE "+quoteSQLString(value.(string)))
+	} else if includeClears && d.HasChange("attribute_json") {
+		clauses = append(clauses, "ATTRIBUTE '{}'")
+	}
+
+	if value, ok := d.GetOk("resource_group"); ok {
+		clauses = append(clauses, "RESOURCE GROUP "+quoteIdentifier(value.(string)))
+	} else if includeClears && d.HasChange("resource_group") {
+		clauses = append(clauses, "RESOURCE GROUP `default`")
+	}
+
+	return clauses
+}
+
+var sqlStringQuoteReplacer = strings.NewReplacer(`\`, `\\`, `'`, `''`)
+
+func quoteSQLString(value string) string {
+	return "'" + sqlStringQuoteReplacer.Replace(value) + "'"
+}
+
+func setTiDBUserOptionsFromCreateStatement(createUserStmt string, d *schema.ResourceData) {
+	if match := regexp.MustCompile(`RESOURCE GROUP [` + "`" + `']?([^` + "`" + `'\s]+)[` + "`" + `']?`).FindStringSubmatch(createUserStmt); len(match) == 2 {
+		d.Set("resource_group", match[1])
+	}
+
+	if match := regexp.MustCompile(`WITH MAX_USER_CONNECTIONS ([0-9]+)`).FindStringSubmatch(createUserStmt); len(match) == 2 {
+		var value int
+		if _, err := fmt.Sscanf(match[1], "%d", &value); err == nil {
+			d.Set("max_user_connections", value)
+		}
+	}
+
+	if strings.Contains(createUserStmt, " ACCOUNT LOCK") {
+		d.Set("account_locked", true)
+	} else if strings.Contains(createUserStmt, " ACCOUNT UNLOCK") {
+		d.Set("account_locked", false)
+	}
+
+	if match := regexp.MustCompile(`COMMENT '((?:''|[^'])*)'`).FindStringSubmatch(createUserStmt); len(match) == 2 {
+		d.Set("comment", unquoteSQLString(match[1]))
+	}
+
+	if match := regexp.MustCompile(`ATTRIBUTE '((?:''|[^'])*)'`).FindStringSubmatch(createUserStmt); len(match) == 2 {
+		d.Set("attribute_json", unquoteSQLString(match[1]))
+	}
+
+	if match := regexp.MustCompile(`PASSWORD EXPIRE (DEFAULT|NEVER|INTERVAL [0-9]+ DAY)`).FindStringSubmatch(createUserStmt); len(match) == 2 {
+		d.Set("password_expire", strings.ToLower(match[1]))
+	}
+
+	if match := regexp.MustCompile(`PASSWORD HISTORY (DEFAULT|[0-9]+)`).FindStringSubmatch(createUserStmt); len(match) == 2 {
+		d.Set("password_history", strings.ToLower(match[1]))
+	}
+
+	if match := regexp.MustCompile(`PASSWORD REUSE INTERVAL (DEFAULT|[0-9]+ DAY)`).FindStringSubmatch(createUserStmt); len(match) == 2 {
+		d.Set("password_reuse_interval", strings.ToLower(match[1]))
+	}
+
+	if match := regexp.MustCompile(`FAILED_LOGIN_ATTEMPTS ([0-9]+)`).FindStringSubmatch(createUserStmt); len(match) == 2 {
+		var value int
+		if _, err := fmt.Sscanf(match[1], "%d", &value); err == nil {
+			d.Set("failed_login_attempts", value)
+		}
+	}
+
+	if match := regexp.MustCompile(`PASSWORD_LOCK_TIME (UNBOUNDED|[0-9]+)`).FindStringSubmatch(createUserStmt); len(match) == 2 {
+		d.Set("password_lock_time", strings.ToLower(match[1]))
+	}
+}
+
+func unquoteSQLString(value string) string {
+	return strings.ReplaceAll(value, "''", "'")
 }

--- a/mysql/resource_user_tidb_unit_test.go
+++ b/mysql/resource_user_tidb_unit_test.go
@@ -1,0 +1,68 @@
+package mysql
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func TestBuildTiDBUserOptionClauses(t *testing.T) {
+	d := schema.TestResourceDataRaw(t, resourceUser().Schema, map[string]interface{}{
+		"resource_group":          "rg_app",
+		"max_user_connections":    20,
+		"account_locked":          true,
+		"comment":                 "app user",
+		"attribute_json":          `{"team":"platform"}`,
+		"password_expire":         "interval 90 day",
+		"password_history":        "5",
+		"password_reuse_interval": "30 day",
+		"failed_login_attempts":   3,
+		"password_lock_time":      "unbounded",
+	})
+
+	got := strings.Join(buildTiDBUserOptionClauses(d, false), " ")
+	want := `WITH MAX_USER_CONNECTIONS 20 PASSWORD EXPIRE INTERVAL 90 DAY PASSWORD HISTORY 5 PASSWORD REUSE INTERVAL 30 DAY FAILED_LOGIN_ATTEMPTS 3 PASSWORD_LOCK_TIME UNBOUNDED ACCOUNT LOCK COMMENT 'app user' ATTRIBUTE '{"team":"platform"}' RESOURCE GROUP ` + "`rg_app`"
+	if got != want {
+		t.Fatalf("buildTiDBUserOptionClauses() = %q, want %q", got, want)
+	}
+}
+
+func TestBuildTiDBUserOptionClausesOmittedBoolDoesNotEmitAccountUnlock(t *testing.T) {
+	d := schema.TestResourceDataRaw(t, resourceUser().Schema, map[string]interface{}{
+		"resource_group": "rg_app",
+	})
+
+	got := strings.Join(buildTiDBUserOptionClauses(d, false), " ")
+	want := "RESOURCE GROUP `rg_app`"
+	if got != want {
+		t.Fatalf("buildTiDBUserOptionClauses() = %q, want %q", got, want)
+	}
+}
+
+func TestSetTiDBUserOptionsFromCreateStatement(t *testing.T) {
+	d := schema.TestResourceDataRaw(t, resourceUser().Schema, map[string]interface{}{})
+	stmt := "CREATE USER `jdoe`@`%` IDENTIFIED WITH `mysql_native_password` REQUIRE NONE PASSWORD EXPIRE INTERVAL 90 DAY PASSWORD HISTORY 5 PASSWORD REUSE INTERVAL 30 DAY FAILED_LOGIN_ATTEMPTS 3 PASSWORD_LOCK_TIME UNBOUNDED ACCOUNT LOCK COMMENT 'app user' ATTRIBUTE '{\"team\":\"platform\"}' RESOURCE GROUP `rg_app`"
+
+	setTiDBUserOptionsFromCreateStatement(stmt, d)
+
+	checks := map[string]interface{}{
+		"resource_group":          "rg_app",
+		"max_user_connections":    0,
+		"account_locked":          true,
+		"comment":                 "app user",
+		"attribute_json":          `{"team":"platform"}`,
+		"password_expire":         "interval 90 day",
+		"password_history":        "5",
+		"password_reuse_interval": "30 day",
+		"failed_login_attempts":   3,
+		"password_lock_time":      "unbounded",
+	}
+
+	for key, want := range checks {
+		if got := d.Get(key); !reflect.DeepEqual(got, want) {
+			t.Fatalf("%s = %#v, want %#v", key, got, want)
+		}
+	}
+}

--- a/mysql/testcontainers_helper.go
+++ b/mysql/testcontainers_helper.go
@@ -440,8 +440,8 @@ func startTiDBCluster(ctx context.Context, t *testing.T, version string) *TiDBTe
 					},
 				}
 			},
-			WaitingFor: wait.ForLog("succeed to update max timestamp").
-				WithOccurrence(3). // Wait for at least 3 region updates - indicates TiKV is ready
+			WaitingFor: wait.ForLog("TiKV is ready to serve").
+				WithOccurrence(1).
 				WithStartupTimeout(180 * time.Second),
 		},
 		Started: true,
@@ -765,8 +765,8 @@ func startSharedTiDBClusterLegacy(version string) (*TiDBTestCluster, error) {
 					},
 				}
 			},
-			WaitingFor: wait.ForLog("succeed to update max timestamp").
-				WithOccurrence(3). // Wait for at least 3 region updates - indicates TiKV is ready
+			WaitingFor: wait.ForLog("TiKV is ready to serve").
+				WithOccurrence(1).
 				WithStartupTimeout(180 * time.Second),
 		},
 		Started: true,

--- a/mysql/tidb_information_schema.go
+++ b/mysql/tidb_information_schema.go
@@ -1,0 +1,74 @@
+package mysql
+
+import (
+	"database/sql"
+	"errors"
+	"strconv"
+	"strings"
+)
+
+func querySingleRowStringMap(db *sql.DB, query string, args ...interface{}) (map[string]string, error) {
+	rows, err := db.Query(query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	if !rows.Next() {
+		if err := rows.Err(); err != nil {
+			return nil, err
+		}
+		return nil, sql.ErrNoRows
+	}
+
+	columns, err := rows.Columns()
+	if err != nil {
+		return nil, err
+	}
+
+	values := make([]sql.NullString, len(columns))
+	scanValues := make([]interface{}, len(columns))
+	for i := range values {
+		scanValues[i] = &values[i]
+	}
+
+	if err := rows.Scan(scanValues...); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	out := make(map[string]string, len(columns))
+	for i, column := range columns {
+		if values[i].Valid {
+			out[strings.ToUpper(column)] = values[i].String
+		} else {
+			out[strings.ToUpper(column)] = ""
+		}
+	}
+
+	if rows.Next() {
+		return nil, errors.New("expected one row, got multiple rows")
+	}
+
+	return out, nil
+}
+
+func stringMapValue(row map[string]string, key string) string {
+	return row[strings.ToUpper(key)]
+}
+
+func stringMapIntValue(row map[string]string, key string) (int, error) {
+	value := strings.TrimSpace(stringMapValue(row, key))
+	if value == "" {
+		return 0, nil
+	}
+
+	parsed, err := strconv.Atoi(value)
+	if err != nil {
+		return 0, err
+	}
+
+	return parsed, nil
+}


### PR DESCRIPTION
## Summary

- Carry forward issue #31 coverage for TiDB runaway query controls.
- Extend `mysql_ti_resource_group` for `UNLIMITED` RU refreshes, TiDB v9 `burstable_mode`, and `BACKGROUND` resource group syntax.
- Add TiDB user syntax to `mysql_user`: `resource_group`, account lock state, comments, attributes, connection limits, and password lifecycle fields.
- Make `mysql_ti_resource_group_user_assignment` host-aware while preserving username-only behavior.
- Expand TiDB placement support with additional `mysql_ti_placement_policy` clauses, new `mysql_ti_placement_range_policy`, and new `mysql_ti_placement_labels` data source.
- Document TiDB `SET GLOBAL` usage through `mysql_global_variable` and cite PingCAP docs in implementation comments.

## Notes

- `SET RESOURCE GROUP`, `CALIBRATE RESOURCE`, query plan bindings, and operational admin commands are intentionally left out of this pass because they are transient, read-only estimation, query-plan management, or operational workflows rather than durable Terraform state.
- TiDB `SHOW PLACEMENT` returns expanded range placement, not the original policy name, so `mysql_ti_placement_range_policy` documents that range policy-name drift cannot be fully detected from TiDB readback.
- `SURVIVAL_PREFERENCES` can be rendered for `CREATE/ALTER PLACEMENT POLICY`, but PingCAP documents no `information_schema.placement_policies` column for it, so drift detection is limited there as well.

## PingCAP References

- https://docs.pingcap.com/tidb/stable/tidb-resource-control-ru-groups/
- https://docs.pingcap.com/tidb/stable/sql-statement-create-resource-group/
- https://docs.pingcap.com/tidb/stable/sql-statement-alter-resource-group/
- https://docs.pingcap.com/tidb/stable/tidb-resource-control-background-tasks/
- https://docs.pingcap.com/tidb/stable/sql-statement-query-watch/
- https://docs.pingcap.com/tidb/stable/placement-rules-in-sql/
- https://docs.pingcap.com/tidb/stable/sql-statement-create-placement-policy/
- https://docs.pingcap.com/tidb/stable/sql-statement-alter-placement-policy/
- https://docs.pingcap.com/tidb/stable/sql-statement-alter-range/
- https://docs.pingcap.com/tidb/stable/sql-statement-show-placement-labels/
- https://docs.pingcap.com/tidb/stable/sql-statement-create-user/
- https://docs.pingcap.com/tidb/stable/sql-statement-alter-user/
- https://docs.pingcap.com/tidb/stable/sql-statement-set-variable/
- https://docs.pingcap.com/tidb/stable/dynamic-config/

## Testing

- `go test ./mysql -run "Test(ResourceGroup|PlacementPolicy|BuildTiDB|SetTiDB|TiDBPlacementRangeTarget)"`
- `go test ./mysql -run "^$"`
- `go test ./mysql ./internal/testmatrix -run "^$"`
- `git diff --check`

`go test ./... -run "^$"` still fails in the existing `scripts` package because multiple standalone `main` files compile together; that is unrelated to this PR.