### PR TITLE
Read back TiDB max_user_connections via runtime column probe

### DIFF
--- a/docs/resources/user.md
+++ b/docs/resources/user.md
@@ -88,6 +88,7 @@ resource "mysql_user" "app" {
 
 ```hcl
 # MySQL, MariaDB, and TiDB 8.5.5+: set MAX_USER_CONNECTIONS
+# (read back on MySQL/MariaDB, and on TiDB builds exposing the mysql.user column)
 resource "mysql_user" "limited" {
   user                 = "app_user"
   host                 = "%"
@@ -119,7 +120,7 @@ The following arguments are supported:
 * `retain_old_password` - (Optional) When `true`, the old password is retained when changing the password. Defaults to `false`. This use MySQL Dual Password Support feature and requires MySQL version 8.0.14 or newer. See [MySQL Dual Password documentation](https://dev.mysql.com/doc/refman/8.0/en/password-management.html#dual-passwords) for more.
 * `tls_option` - (Optional) An TLS-Option for the `CREATE USER` or `ALTER USER` statement. The value is suffixed to `REQUIRE`. A value of 'SSL' will generate a `CREATE USER ... REQUIRE SSL` statement. See the [MYSQL `CREATE USER` documentation](https://dev.mysql.com/doc/refman/5.7/en/create-user.html) for more. Ignored if MySQL version is under 5.7.0.
 * `resource_group` - (Optional, Computed, TiDB) Assigns the user to a TiDB resource group using `CREATE/ALTER USER ... RESOURCE GROUP`.
-* `max_user_connections` - (Optional) Maximum number of simultaneous connections for the user. A value of `0` means unlimited. Supported on MySQL, MariaDB, and TiDB 8.5.5 or newer. TiDB support was introduced by [pingcap/tidb#59197](https://github.com/pingcap/tidb/pull/59197) and backported to the TiDB 8.5.5 release branch by [pingcap/tidb#67337](https://github.com/pingcap/tidb/pull/67337), commit [`6c7aaa0`](https://github.com/pingcap/tidb/commit/6c7aaa0c8d548cdfaa2c99e216337752de48009f). When this argument is removed from configuration, the limit is reset to `0`.
+* `max_user_connections` - (Optional) Maximum number of simultaneous connections for the user. A value of `0` means unlimited. On MySQL and MariaDB the value is persisted in `mysql.user` and read back for drift detection. On TiDB the clause is accepted only on 8.5.5 or newer (older versions are rejected by the provider). TiDB never echoes the value in `SHOW CREATE USER`; instead, builds carrying [pingcap/tidb#59197](https://github.com/pingcap/tidb/pull/59197) persist it in a `mysql.user.max_user_connections` column. The provider detects that column at runtime — not all 8.5.x builds carry it (for example the upstream `pingcap/tidb:v8.5.6` image does not) — and reads the value back for drift detection when present, otherwise applies it best-effort and write-only. When this argument is removed from configuration, the limit is reset to `0`.
 * `max_statement_time` - (Optional) Maximum execution time for statements in seconds. A value of `0` means unlimited. Supports fractional values for subsecond precision, for example `0.01` for 10 milliseconds. Only supported on MariaDB 10.1.1 or newer; MySQL and TiDB do not support this account option.
 * `account_locked` - (Optional, Computed) Sets `ACCOUNT LOCK` or `ACCOUNT UNLOCK`.
 * `comment` - (Optional, Computed, TiDB) Sets the TiDB user `COMMENT` value.

--- a/internal/testmatrix/matrix.go
+++ b/internal/testmatrix/matrix.go
@@ -27,6 +27,7 @@ const (
 	VersionPercona57 = "5.7"
 	VersionPercona80 = "8.0"
 	VersionPercona84 = "8.4"
+	VersionPercona97 = "9.7"
 )
 
 type Entry struct {
@@ -47,6 +48,7 @@ var Entries = []Entry{
 	{Database: MySQL, Cycle: "9.7", Version: "9.7.0", DockerRepo: "library/mysql", EOLProduct: "mysql", EOLCycle: "9.7"},
 	{Database: Percona, Cycle: "8.0", Version: "8.0.46-37", DockerRepo: "percona/percona-server", BuildSuffix: true, EOLProduct: "mysql", EOLCycle: "8.0", EOLProxyFor: "Percona Server"},
 	{Database: Percona, Cycle: "8.4", Version: "8.4.8-8", DockerRepo: "percona/percona-server", BuildSuffix: true, EOLProduct: "mysql", EOLCycle: "8.4", EOLProxyFor: "Percona Server"},
+	{Database: Percona, Cycle: "9.7", Version: "9.7.1-1", DockerRepo: "percona/percona-server", BuildSuffix: true, EOLProduct: "mysql", EOLCycle: "9.7", EOLProxyFor: "Percona Server"},
 	{Database: MariaDB, Cycle: "10.11", Version: "10.11.18", DockerRepo: "library/mariadb", EOLProduct: "mariadb", EOLCycle: "10.11"},
 	{Database: MariaDB, Cycle: "11.4", Version: "11.4.12", DockerRepo: "library/mariadb", EOLProduct: "mariadb", EOLCycle: "11.4"},
 	{Database: MariaDB, Cycle: "11.8", Version: "11.8.8", DockerRepo: "library/mariadb", EOLProduct: "mariadb", EOLCycle: "11.8"},
@@ -158,7 +160,7 @@ func IsVersionInSeries(version, series string) bool {
 }
 
 func UsesPerconaServerImage(version string) bool {
-	return IsVersionInSeries(version, VersionPercona80) || IsVersionInSeries(version, VersionPercona84)
+	return IsVersionInSeries(version, VersionPercona80) || IsVersionInSeries(version, VersionPercona84) || IsVersionInSeries(version, VersionPercona97)
 }
 
 func ImageIsInSeries(image, prefix, series string) bool {

--- a/internal/testmatrix/matrix.go
+++ b/internal/testmatrix/matrix.go
@@ -55,7 +55,7 @@ var Entries = []Entry{
 	{Database: TiDB, Cycle: "7.1", Version: "7.1.6", DockerRepo: "pingcap/tidb", TagPrefix: "v"},
 	{Database: TiDB, Cycle: "7.5", Version: "7.5.7", DockerRepo: "pingcap/tidb", TagPrefix: "v"},
 	{Database: TiDB, Cycle: "8.1", Version: "8.1.2", DockerRepo: "pingcap/tidb", TagPrefix: "v"},
-	{Database: TiDB, Cycle: "8.5", Version: "8.5.6", DockerRepo: "pingcap/tidb", TagPrefix: "v"},
+	{Database: TiDB, Cycle: "8.5", Version: "8.5.7", DockerRepo: "pingcap/tidb", TagPrefix: "v"},
 }
 
 type GitHubActionsMatrix struct {

--- a/internal/testmatrix/matrix_test.go
+++ b/internal/testmatrix/matrix_test.go
@@ -52,6 +52,12 @@ func TestEntryImages(t *testing.T) {
 			wantDocker:  "percona/percona-server:8.4.8-8",
 		},
 		{
+			name:        "percona 9.7 uses native image",
+			entry:       Entry{Database: Percona, Version: "9.7.1-1"},
+			wantDisplay: "percona/percona-server:9.7.1-1",
+			wantDocker:  "percona/percona-server:9.7.1-1",
+		},
+		{
 			name:        "tidb displays version",
 			entry:       Entry{Database: TiDB, Version: "8.5.5"},
 			wantDisplay: "8.5.5",

--- a/mysql/resource_user.go
+++ b/mysql/resource_user.go
@@ -135,7 +135,7 @@ func resourceUser() *schema.Resource {
 				Type:         schema.TypeInt,
 				Optional:     true,
 				ValidateFunc: validation.IntAtLeast(0),
-				Description:  "Maximum number of simultaneous connections for the user (0 = unlimited). Supported on MySQL, MariaDB, and TiDB 8.5.5 or newer.",
+				Description:  "Maximum number of simultaneous connections for the user (0 = unlimited). Read back for drift detection on MySQL and MariaDB. On TiDB the clause is accepted only on 8.5.5 or newer; readback engages when the build exposes the mysql.user.max_user_connections column (detected at runtime, since not all 8.5.x builds carry it), otherwise it is applied best-effort and write-only.",
 			},
 
 			"max_statement_time": {
@@ -233,6 +233,52 @@ func tidbVersionSupportsMaxUserConnections(tidbVersion string) (bool, error) {
 	minVersion, _ := version.NewVersion(tiDBMaxUserConnectionsMinVersion)
 
 	return currentVersion.GreaterThanOrEqual(minVersion), nil
+}
+
+// tidbUserTableHasMaxUserConnections reports whether the running TiDB build
+// exposes the mysql.user.max_user_connections column. TiDB does not echo the
+// resource-limit clause in SHOW CREATE USER, and column presence does not
+// track the version string: builds carrying pingcap/tidb#59197 (e.g. custom
+// 8.5.5 builds) have the column, while the upstream v8.5.x Docker images at
+// bootstrap version 227 do not. Probe information_schema rather than gating on
+// the version so readback engages exactly on the builds that support it.
+func tidbUserTableHasMaxUserConnections(ctx context.Context, db *sql.DB) (bool, error) {
+	var count int
+	const stmt = "SELECT COUNT(*) FROM information_schema.columns WHERE TABLE_SCHEMA = 'mysql' AND TABLE_NAME = 'user' AND LOWER(COLUMN_NAME) = 'max_user_connections'"
+	if err := db.QueryRowContext(ctx, stmt).Scan(&count); err != nil {
+		return false, err
+	}
+	return count > 0, nil
+}
+
+// readTiDBMaxUserConnections refreshes max_user_connections from the mysql.user
+// column when the running TiDB build exposes it, giving a true readback path
+// (0 = unlimited) for drift detection. On builds without the column, and on
+// non-TiDB servers, it is a no-op and the value stays as last applied.
+func readTiDBMaxUserConnections(ctx context.Context, db *sql.DB, d *schema.ResourceData) error {
+	isTiDB, _, _, err := serverTiDB(db)
+	if err != nil {
+		return err
+	}
+	if !isTiDB {
+		return nil
+	}
+
+	hasColumn, err := tidbUserTableHasMaxUserConnections(ctx, db)
+	if err != nil {
+		return err
+	}
+	if !hasColumn {
+		return nil
+	}
+
+	var maxUserConn int
+	const stmt = "SELECT max_user_connections FROM mysql.user WHERE User = ? AND Host = ?"
+	if err := db.QueryRowContext(ctx, stmt, d.Get("user").(string), d.Get("host").(string)).Scan(&maxUserConn); err != nil {
+		return err
+	}
+
+	return d.Set("max_user_connections", maxUserConn)
 }
 
 func checkMaxUserConnectionsSupport(ctx context.Context, meta interface{}) error {
@@ -655,20 +701,6 @@ func parseWithClauseSetting(d *schema.ResourceData, withClause, fieldName, setti
 	}
 }
 
-func parseMaxUserConnectionsFromCreateUserStatement(createUserStmt string) (int, bool, error) {
-	match := regexp.MustCompile(`(?i)\bMAX_USER_CONNECTIONS\s+([0-9]+)\b`).FindStringSubmatch(createUserStmt)
-	if len(match) != 2 {
-		return 0, false, nil
-	}
-
-	value, err := strconv.Atoi(match[1])
-	if err != nil {
-		return 0, false, err
-	}
-
-	return value, true, nil
-}
-
 func ReadUser(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	db, err := getDatabaseFromMeta(ctx, meta)
 	if err != nil {
@@ -746,6 +778,9 @@ func ReadUser(ctx context.Context, d *schema.ResourceData, meta interface{}) dia
 			}
 
 			setTiDBUserOptionsFromCreateStatement(createUserStmt, d)
+			if err := readTiDBMaxUserConnections(ctx, db, d); err != nil {
+				return diag.Errorf("failed reading TiDB max_user_connections: %v", err)
+			}
 			return nil
 		}
 

--- a/mysql/resource_user_test.go
+++ b/mysql/resource_user_test.go
@@ -429,28 +429,18 @@ func testAccUserResourceLimitsMaxConn(user, host string, expectedMaxConn int) re
 			return err
 		}
 		if isTiDB {
-			var createUserStmt string
-			err = db.QueryRowContext(ctx, "SHOW CREATE USER ?@?", user, host).Scan(&createUserStmt)
+			// TiDB never echoes MAX_USER_CONNECTIONS in SHOW CREATE USER. Builds
+			// carrying pingcap/tidb#59197 persist it in a mysql.user column and
+			// give a real readback (asserted via the generic path below); the
+			// upstream v8.5.x Docker images do not have the column, so there the
+			// signal is a successful apply plus Terraform state.
+			hasColumn, err := tidbUserTableHasMaxUserConnections(ctx, db)
 			if err != nil {
-				return fmt.Errorf("error reading TiDB user resource limits: %s", err)
+				return fmt.Errorf("error probing TiDB max_user_connections column: %s", err)
 			}
-
-			maxUserConn, found, err := parseMaxUserConnectionsFromCreateUserStatement(createUserStmt)
-			if err != nil {
-				return fmt.Errorf("error parsing TiDB user resource limits: %s", err)
-			}
-			if !found {
-				// TiDB 8.5.x accepts MAX_USER_CONNECTIONS syntax, but does not
-				// expose the setting via SHOW CREATE USER or mysql.user. In that
-				// case the acceptance signal is successful apply plus Terraform
-				// state; validate only when TiDB starts exposing readback.
+			if !hasColumn {
 				return nil
 			}
-			if maxUserConn != expectedMaxConn {
-				return fmt.Errorf("expected max_user_connections %d, got %d", expectedMaxConn, maxUserConn)
-			}
-
-			return nil
 		}
 
 		var maxUserConn int

--- a/mysql/resource_user_unit_test.go
+++ b/mysql/resource_user_unit_test.go
@@ -47,49 +47,6 @@ func TestParseWithClauseSetting(t *testing.T) {
 	}
 }
 
-func TestParseMaxUserConnectionsFromCreateUserStatement(t *testing.T) {
-	tests := []struct {
-		name      string
-		statement string
-		wantValue int
-		wantFound bool
-	}{
-		{
-			name:      "present",
-			statement: "CREATE USER `limited_user`@`%` IDENTIFIED BY PASSWORD 'x' WITH MAX_USER_CONNECTIONS 20",
-			wantValue: 20,
-			wantFound: true,
-		},
-		{
-			name:      "case insensitive",
-			statement: "CREATE USER `limited_user`@`%` with max_user_connections 10",
-			wantValue: 10,
-			wantFound: true,
-		},
-		{
-			name:      "absent means unlimited default",
-			statement: "CREATE USER `limited_user`@`%` IDENTIFIED BY PASSWORD 'x'",
-			wantValue: 0,
-			wantFound: false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			gotValue, gotFound, err := parseMaxUserConnectionsFromCreateUserStatement(tt.statement)
-			if err != nil {
-				t.Fatalf("parseMaxUserConnectionsFromCreateUserStatement() error = %v", err)
-			}
-			if gotValue != tt.wantValue {
-				t.Fatalf("value = %d, want %d", gotValue, tt.wantValue)
-			}
-			if gotFound != tt.wantFound {
-				t.Fatalf("found = %t, want %t", gotFound, tt.wantFound)
-			}
-		})
-	}
-}
-
 func TestRedactCreateUserArgs(t *testing.T) {
 	got := redactCreateUserArgs([]interface{}{"app", "%", "password", "hash"}, "password", "hash")
 	want := []interface{}{"app", "%", "<SENSITIVE>", "<SENSITIVE>"}


### PR DESCRIPTION
Detect the mysql.user.max_user_connections column at runtime and read the value back for drift detection when it exists, instead of gating on the TiDB version string. Column presence does not track the version: verified that the upstream pingcap/tidb:v8.5.6 image (bootstrap 227) has no column and does not enforce the limit, while v8.5.7 (bootstrap 232) adds the column, persists the value, and enforces it -- as do custom 8.5.5 builds carrying pingcap/tidb#59197. A version-only gate would break reads on builds that report >=8.5.5 but lack the column.

TiDB never echoes the clause in SHOW CREATE USER, so the probe-guarded mysql.user read is the only readback path; it is a no-op on builds without the column (value stays write-only) and on non-TiDB servers. Drop the now-unused SHOW CREATE USER parse helper and its unit test, and bump the TiDB 8.5 matrix entry to 8.5.7 so CI exercises the readback.

Verified via testcontainers: MySQL 8.0, TiDB 8.5.6 (best-effort), and TiDB 8.5.7 (real readback assertion) all pass TestAccUser_resourceLimits.