### PR TITLE
fix: compare TiDB core version so suffixed 8.5.5 builds pass the MAX_USER_CONNECTIONS gate

### DIFF
--- a/mysql/resource_user.go
+++ b/mysql/resource_user.go
@@ -232,7 +232,11 @@ func tidbVersionSupportsMaxUserConnections(tidbVersion string) (bool, error) {
 	}
 	minVersion, _ := version.NewVersion(tiDBMaxUserConnectionsMinVersion)
 
-	return currentVersion.GreaterThanOrEqual(minVersion), nil
+	// TiDB appends a build date and commit hash (e.g. "v8.5.5-YYYYMMDD-<hash>");
+	// go-version parses that trailing segment as a semver prerelease, and a
+	// prerelease sorts below the release (8.5.5-<build> < 8.5.5). Compare on the
+	// core X.Y.Z so genuine 8.5.5 builds are accepted.
+	return currentVersion.Core().GreaterThanOrEqual(minVersion), nil
 }
 
 // tidbUserTableHasMaxUserConnections reports whether the running TiDB build

--- a/mysql/resource_user_unit_test.go
+++ b/mysql/resource_user_unit_test.go
@@ -16,6 +16,14 @@ func TestTiDBVersionSupportsMaxUserConnections(t *testing.T) {
 		{version: "v8.5.5", want: true},
 		{version: "8.5.6", want: true},
 		{version: "9.0.0", want: true},
+		// Real TiDB builds append a date/hash that serverTiDB carries through
+		// (e.g. VERSION() "8.0.11-TiDB-v8.5.5-20250115-a1b2c3d" yields this).
+		// go-version reads the suffix as a prerelease, so the comparison must
+		// run on the core version rather than reject a genuine 8.5.5.
+		{version: "v8.5.5-20250115-a1b2c3d", want: true},
+		{version: "8.5.5-20250115-a1b2c3d", want: true},
+		{version: "v8.5.4-20250115-a1b2c3d", want: false},
+		{version: "v8.5.6-20250115-a1b2c3d", want: true},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Problem

`mysql_user.max_user_connections` fails against a genuine TiDB **v8.5.5** server with:

```
Error: MAX_USER_CONNECTIONS is only supported on TiDB 8.5.5 or newer
```

TiDB's `SELECT @@GLOBAL.version` returns a build-suffixed string like `8.0.11-TiDB-v8.5.5-YYYYMMDD-<hash>`. `serverTiDB()` splits on `-` and returns the third segment, `v8.5.5-YYYYMMDD-<hash>`, as the TiDB version. `tidbVersionSupportsMaxUserConnections()` then hands that to `version.NewVersion`, where hashicorp/go-version parses the trailing `-YYYYMMDD-<hash>` as a **semver prerelease**. A prerelease sorts *below* the release, so `8.5.5-<build>` < `8.5.5`, and the `>= 8.5.5` check rejects the server.

This bites any TiDB build whose core version equals the gate minimum (8.5.5) and carries a build suffix, which is the norm for real deployments. (An 8.5.6+ core passes, because the core comparison decides before prerelease matters.) The `information_schema` column readback added in #37 is unaffected; this is purely the write-path version gate.

## Fix

Compare on the core `X.Y.Z` via `Version.Core()`, so the build suffix no longer drags the version below the minimum. Adds unit cases for build-suffixed version strings, which the previous tests (clean versions only) never exercised.

## Testing

`go test ./mysql/ -run TestTiDBVersionSupportsMaxUserConnections` passes. The new suffix cases fail without the one-line change and pass with it.
